### PR TITLE
Implement SHA3-512 Hash Function

### DIFF
--- a/bench/main.cpp
+++ b/bench/main.cpp
@@ -24,5 +24,15 @@ BENCHMARK(bench_sha3::sha3_256)->Arg(1024);
 BENCHMARK(bench_sha3::sha3_256)->Arg(2048);
 BENCHMARK(bench_sha3::sha3_256)->Arg(4096);
 
+// register sha3-384 hash function for benchmark
+BENCHMARK(bench_sha3::sha3_384)->Arg(32);
+BENCHMARK(bench_sha3::sha3_384)->Arg(64);
+BENCHMARK(bench_sha3::sha3_384)->Arg(128);
+BENCHMARK(bench_sha3::sha3_384)->Arg(256);
+BENCHMARK(bench_sha3::sha3_384)->Arg(512);
+BENCHMARK(bench_sha3::sha3_384)->Arg(1024);
+BENCHMARK(bench_sha3::sha3_384)->Arg(2048);
+BENCHMARK(bench_sha3::sha3_384)->Arg(4096);
+
 // benchmark runner main routine
 BENCHMARK_MAIN();

--- a/bench/main.cpp
+++ b/bench/main.cpp
@@ -34,5 +34,15 @@ BENCHMARK(bench_sha3::sha3_384)->Arg(1024);
 BENCHMARK(bench_sha3::sha3_384)->Arg(2048);
 BENCHMARK(bench_sha3::sha3_384)->Arg(4096);
 
+// register sha3-512 hash function for benchmark
+BENCHMARK(bench_sha3::sha3_512)->Arg(32);
+BENCHMARK(bench_sha3::sha3_512)->Arg(64);
+BENCHMARK(bench_sha3::sha3_512)->Arg(128);
+BENCHMARK(bench_sha3::sha3_512)->Arg(256);
+BENCHMARK(bench_sha3::sha3_512)->Arg(512);
+BENCHMARK(bench_sha3::sha3_512)->Arg(1024);
+BENCHMARK(bench_sha3::sha3_512)->Arg(2048);
+BENCHMARK(bench_sha3::sha3_512)->Arg(4096);
+
 // benchmark runner main routine
 BENCHMARK_MAIN();

--- a/bench/main.cpp
+++ b/bench/main.cpp
@@ -14,5 +14,15 @@ BENCHMARK(bench_sha3::sha3_224)->Arg(1024);
 BENCHMARK(bench_sha3::sha3_224)->Arg(2048);
 BENCHMARK(bench_sha3::sha3_224)->Arg(4096);
 
+// register sha3-256 hash function for benchmark
+BENCHMARK(bench_sha3::sha3_256)->Arg(32);
+BENCHMARK(bench_sha3::sha3_256)->Arg(64);
+BENCHMARK(bench_sha3::sha3_256)->Arg(128);
+BENCHMARK(bench_sha3::sha3_256)->Arg(256);
+BENCHMARK(bench_sha3::sha3_256)->Arg(512);
+BENCHMARK(bench_sha3::sha3_256)->Arg(1024);
+BENCHMARK(bench_sha3::sha3_256)->Arg(2048);
+BENCHMARK(bench_sha3::sha3_256)->Arg(4096);
+
 // benchmark runner main routine
 BENCHMARK_MAIN();

--- a/include/bench_sha3.hpp
+++ b/include/bench_sha3.hpp
@@ -1,12 +1,13 @@
 #pragma once
 #include "sha3_224.hpp"
+#include "sha3_256.hpp"
 #include "utils.hpp"
 #include <benchmark/benchmark.h>
 
 // Benchmarks SHA3 functions on CPU systems, using google-benchmark
 namespace bench_sha3 {
 
-// Benchmarks SHA3-224 hash function for specified number of random input bytes
+// Benchmarks SHA3-224 hash function with specified number of random input bytes
 static void
 sha3_224(benchmark::State& state)
 {
@@ -21,6 +22,30 @@ sha3_224(benchmark::State& state)
 
   for (auto _ : state) {
     sha3_224::hash(msg, mlen, dig);
+
+    benchmark::DoNotOptimize(dig);
+    benchmark::ClobberMemory();
+  }
+
+  const size_t tot_bytes = state.iterations() * mlen;
+  state.SetBytesProcessed(static_cast<int64_t>(tot_bytes));
+}
+
+// Benchmarks SHA3-256 hash function with specified number of random input bytes
+static void
+sha3_256(benchmark::State& state)
+{
+  const size_t mlen = static_cast<size_t>(state.range(0));
+  assert(mlen > 0);
+
+  uint8_t* msg = static_cast<uint8_t*>(std::malloc(mlen));
+  uint8_t* dig = static_cast<uint8_t*>(std::malloc(32));
+
+  random_data<uint8_t>(msg, mlen);
+  std::memset(dig, 0, 32);
+
+  for (auto _ : state) {
+    sha3_256::hash(msg, mlen, dig);
 
     benchmark::DoNotOptimize(dig);
     benchmark::ClobberMemory();

--- a/include/bench_sha3.hpp
+++ b/include/bench_sha3.hpp
@@ -2,6 +2,7 @@
 #include "sha3_224.hpp"
 #include "sha3_256.hpp"
 #include "sha3_384.hpp"
+#include "sha3_512.hpp"
 #include "utils.hpp"
 #include <benchmark/benchmark.h>
 
@@ -71,6 +72,30 @@ sha3_384(benchmark::State& state)
 
   for (auto _ : state) {
     sha3_384::hash(msg, mlen, dig);
+
+    benchmark::DoNotOptimize(dig);
+    benchmark::ClobberMemory();
+  }
+
+  const size_t tot_bytes = state.iterations() * mlen;
+  state.SetBytesProcessed(static_cast<int64_t>(tot_bytes));
+}
+
+// Benchmarks SHA3-512 hash function with specified number of random input bytes
+static void
+sha3_512(benchmark::State& state)
+{
+  const size_t mlen = static_cast<size_t>(state.range(0));
+  assert(mlen > 0);
+
+  uint8_t* msg = static_cast<uint8_t*>(std::malloc(mlen));
+  uint8_t* dig = static_cast<uint8_t*>(std::malloc(64));
+
+  random_data<uint8_t>(msg, mlen);
+  std::memset(dig, 0, 64);
+
+  for (auto _ : state) {
+    sha3_512::hash(msg, mlen, dig);
 
     benchmark::DoNotOptimize(dig);
     benchmark::ClobberMemory();

--- a/include/bench_sha3.hpp
+++ b/include/bench_sha3.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "sha3_224.hpp"
 #include "sha3_256.hpp"
+#include "sha3_384.hpp"
 #include "utils.hpp"
 #include <benchmark/benchmark.h>
 
@@ -46,6 +47,30 @@ sha3_256(benchmark::State& state)
 
   for (auto _ : state) {
     sha3_256::hash(msg, mlen, dig);
+
+    benchmark::DoNotOptimize(dig);
+    benchmark::ClobberMemory();
+  }
+
+  const size_t tot_bytes = state.iterations() * mlen;
+  state.SetBytesProcessed(static_cast<int64_t>(tot_bytes));
+}
+
+// Benchmarks SHA3-384 hash function with specified number of random input bytes
+static void
+sha3_384(benchmark::State& state)
+{
+  const size_t mlen = static_cast<size_t>(state.range(0));
+  assert(mlen > 0);
+
+  uint8_t* msg = static_cast<uint8_t*>(std::malloc(mlen));
+  uint8_t* dig = static_cast<uint8_t*>(std::malloc(48));
+
+  random_data<uint8_t>(msg, mlen);
+  std::memset(dig, 0, 48);
+
+  for (auto _ : state) {
+    sha3_384::hash(msg, mlen, dig);
 
     benchmark::DoNotOptimize(dig);
     benchmark::ClobberMemory();

--- a/include/sha3_256.hpp
+++ b/include/sha3_256.hpp
@@ -1,0 +1,27 @@
+#pragma once
+#include "sponge.hpp"
+
+// SHA3-256 Hash Function : Keccak[512](M || 01, 256)
+namespace sha3_256 {
+
+// Given N -bytes input message, this routine consumes it into keccak[512]
+// sponge state and squeezes out 32 -bytes digest | N >= 0
+//
+// See SHA3 hash function definition in section 6.1 of SHA3 specification
+// https://dx.doi.org/10.6028/NIST.FIPS.202
+static void
+hash(const uint8_t* const __restrict msg,
+     const size_t mlen,
+     uint8_t* const __restrict dig)
+{
+  constexpr size_t dlen = 256;
+  constexpr size_t capacity = 2 * dlen;
+  constexpr size_t rate = 1600 - capacity;
+
+  uint64_t state[25]{};
+
+  sponge::absorb<0b00000010, 2, rate>(state, msg, mlen);
+  sponge::squeeze<rate>(state, dig, dlen >> 3);
+}
+
+}

--- a/include/sha3_384.hpp
+++ b/include/sha3_384.hpp
@@ -1,0 +1,27 @@
+#pragma once
+#include "sponge.hpp"
+
+// SHA3-384 Hash Function : Keccak[768](M || 01, 384)
+namespace sha3_384 {
+
+// Given N -bytes input message, this routine consumes it into keccak[768]
+// sponge state and squeezes out 48 -bytes digest | N >= 0
+//
+// See SHA3 hash function definition in section 6.1 of SHA3 specification
+// https://dx.doi.org/10.6028/NIST.FIPS.202
+static void
+hash(const uint8_t* const __restrict msg,
+     const size_t mlen,
+     uint8_t* const __restrict dig)
+{
+  constexpr size_t dlen = 384;
+  constexpr size_t capacity = 2 * dlen;
+  constexpr size_t rate = 1600 - capacity;
+
+  uint64_t state[25]{};
+
+  sponge::absorb<0b00000010, 2, rate>(state, msg, mlen);
+  sponge::squeeze<rate>(state, dig, dlen >> 3);
+}
+
+}

--- a/include/sha3_512.hpp
+++ b/include/sha3_512.hpp
@@ -1,0 +1,27 @@
+#pragma once
+#include "sponge.hpp"
+
+// SHA3-512 Hash Function : Keccak[1024](M || 01, 512)
+namespace sha3_512 {
+
+// Given N -bytes input message, this routine consumes it into keccak[1024]
+// sponge state and squeezes out 64 -bytes digest | N >= 0
+//
+// See SHA3 hash function definition in section 6.1 of SHA3 specification
+// https://dx.doi.org/10.6028/NIST.FIPS.202
+static void
+hash(const uint8_t* const __restrict msg,
+     const size_t mlen,
+     uint8_t* const __restrict dig)
+{
+  constexpr size_t dlen = 512;
+  constexpr size_t capacity = 2 * dlen;
+  constexpr size_t rate = 1600 - capacity;
+
+  uint64_t state[25]{};
+
+  sponge::absorb<0b00000010, 2, rate>(state, msg, mlen);
+  sponge::squeeze<rate>(state, dig, dlen >> 3);
+}
+
+}

--- a/wrapper/python/sha3.py
+++ b/wrapper/python/sha3.py
@@ -61,5 +61,23 @@ def sha3_256_hash(msg: bytes) -> bytes:
     return digest_
 
 
+def sha3_384_hash(msg: bytes) -> bytes:
+    """
+    Given a N ( >= 0 ) -bytes input message, this function computes 48 -bytes
+    SHA3-384 digest
+    """
+    mlen = len(msg)
+    msg_ = np.frombuffer(msg, dtype=u8)
+    digest = np.empty(48, dtype=u8)
+
+    args = [uint8_tp, len_t, uint8_tp]
+    SO_LIB.sha3_384_hash.argtypes = args
+
+    SO_LIB.sha3_384_hash(msg_, mlen, digest)
+
+    digest_ = digest.tobytes()
+    return digest_
+
+
 if __name__ == "__main__":
     print("Use `sha3` as a library module")

--- a/wrapper/python/sha3.py
+++ b/wrapper/python/sha3.py
@@ -79,5 +79,23 @@ def sha3_384_hash(msg: bytes) -> bytes:
     return digest_
 
 
+def sha3_512_hash(msg: bytes) -> bytes:
+    """
+    Given a N ( >= 0 ) -bytes input message, this function computes 64 -bytes
+    SHA3-512 digest
+    """
+    mlen = len(msg)
+    msg_ = np.frombuffer(msg, dtype=u8)
+    digest = np.empty(64, dtype=u8)
+
+    args = [uint8_tp, len_t, uint8_tp]
+    SO_LIB.sha3_512_hash.argtypes = args
+
+    SO_LIB.sha3_512_hash(msg_, mlen, digest)
+
+    digest_ = digest.tobytes()
+    return digest_
+
+
 if __name__ == "__main__":
     print("Use `sha3` as a library module")

--- a/wrapper/python/sha3.py
+++ b/wrapper/python/sha3.py
@@ -43,5 +43,23 @@ def sha3_224_hash(msg: bytes) -> bytes:
     return digest_
 
 
+def sha3_256_hash(msg: bytes) -> bytes:
+    """
+    Given a N ( >= 0 ) -bytes input message, this function computes 32 -bytes
+    SHA3-256 digest
+    """
+    mlen = len(msg)
+    msg_ = np.frombuffer(msg, dtype=u8)
+    digest = np.empty(32, dtype=u8)
+
+    args = [uint8_tp, len_t, uint8_tp]
+    SO_LIB.sha3_256_hash.argtypes = args
+
+    SO_LIB.sha3_256_hash(msg_, mlen, digest)
+
+    digest_ = digest.tobytes()
+    return digest_
+
+
 if __name__ == "__main__":
     print("Use `sha3` as a library module")

--- a/wrapper/python/test_sha3.py
+++ b/wrapper/python/test_sha3.py
@@ -4,8 +4,8 @@ import random
 import hashlib
 import sha3
 
-FROM_BYTES = 0
-TO_BYTES = 1024
+FROM_BYTES = 0  # minimum test input message byte length
+TO_BYTES = 1024  # maximum test input message byte length
 
 
 def gen_rand_bytes(n: int) -> bytes:
@@ -22,8 +22,24 @@ def test_sha3_224_hash():
         dig0 = sha3.sha3_224_hash(msg)
         dig1 = hashlib.sha3_224(msg).digest()
 
-        flg = dig0 == dig1
-        assert flg, f"Expected {dig1.hex()}, found {dig0.hex()}, for input {msg.hex()}"
+        assert (
+            dig0 == dig1
+        ), f"[SHA3-224] Expected {dig1.hex()}, found {dig0.hex()}, for input {msg.hex()}"
+
+
+def test_sha3_256_hash():
+    """
+    Test functional correctness of SHA3-256 hash function implementation
+    """
+    for i in range(FROM_BYTES, TO_BYTES + 1):
+        msg = gen_rand_bytes(i)
+
+        dig0 = sha3.sha3_256_hash(msg)
+        dig1 = hashlib.sha3_256(msg).digest()
+
+        assert (
+            dig0 == dig1
+        ), f"[SHA3-256] Expected {dig1.hex()}, found {dig0.hex()}, for input {msg.hex()}"
 
 
 if __name__ == "__main__":

--- a/wrapper/python/test_sha3.py
+++ b/wrapper/python/test_sha3.py
@@ -42,5 +42,20 @@ def test_sha3_256_hash():
         ), f"[SHA3-256] Expected {dig1.hex()}, found {dig0.hex()}, for input {msg.hex()}"
 
 
+def test_sha3_384_hash():
+    """
+    Test functional correctness of SHA3-384 hash function implementation
+    """
+    for i in range(FROM_BYTES, TO_BYTES + 1):
+        msg = gen_rand_bytes(i)
+
+        dig0 = sha3.sha3_384_hash(msg)
+        dig1 = hashlib.sha3_384(msg).digest()
+
+        assert (
+            dig0 == dig1
+        ), f"[SHA3-384] Expected {dig1.hex()}, found {dig0.hex()}, for input {msg.hex()}"
+
+
 if __name__ == "__main__":
     print("Use `pytest` for executing test cases")

--- a/wrapper/python/test_sha3.py
+++ b/wrapper/python/test_sha3.py
@@ -57,5 +57,20 @@ def test_sha3_384_hash():
         ), f"[SHA3-384] Expected {dig1.hex()}, found {dig0.hex()}, for input {msg.hex()}"
 
 
+def test_sha3_512_hash():
+    """
+    Test functional correctness of SHA3-512 hash function implementation
+    """
+    for i in range(FROM_BYTES, TO_BYTES + 1):
+        msg = gen_rand_bytes(i)
+
+        dig0 = sha3.sha3_512_hash(msg)
+        dig1 = hashlib.sha3_512(msg).digest()
+
+        assert (
+            dig0 == dig1
+        ), f"[SHA3-512] Expected {dig1.hex()}, found {dig0.hex()}, for input {msg.hex()}"
+
+
 if __name__ == "__main__":
     print("Use `pytest` for executing test cases")

--- a/wrapper/sha3.cpp
+++ b/wrapper/sha3.cpp
@@ -1,4 +1,5 @@
 #include "sha3_224.hpp"
+#include "sha3_256.hpp"
 
 // Thin C wrapper on top of underlying C++ implementation of SHA3 hash functions
 // and XOFs, which can be used for producing shared library object with
@@ -8,6 +9,11 @@
 extern "C"
 {
   void sha3_224_hash(const uint8_t* const __restrict, // input message
+                     const size_t,                    // input byte length
+                     uint8_t* const __restrict        // output digest
+  );
+
+  void sha3_256_hash(const uint8_t* const __restrict, // input message
                      const size_t,                    // input byte length
                      uint8_t* const __restrict        // output digest
   );
@@ -26,5 +32,16 @@ extern "C"
   )
   {
     sha3_224::hash(in, ilen, out);
+  }
+
+  // Given N (>=0) -bytes input message, this routines computes 32 -bytes output
+  // digest, using SHA3-256 hashing algorithm
+  void sha3_256_hash(
+    const uint8_t* const __restrict in, // input message
+    const size_t ilen,                  // len(in) | >= 0
+    uint8_t* const __restrict out       // 32 -bytes digest, to be computed
+  )
+  {
+    sha3_256::hash(in, ilen, out);
   }
 }

--- a/wrapper/sha3.cpp
+++ b/wrapper/sha3.cpp
@@ -1,6 +1,7 @@
 #include "sha3_224.hpp"
 #include "sha3_256.hpp"
 #include "sha3_384.hpp"
+#include "sha3_512.hpp"
 
 // Thin C wrapper on top of underlying C++ implementation of SHA3 hash functions
 // and XOFs, which can be used for producing shared library object with
@@ -20,6 +21,11 @@ extern "C"
   );
 
   void sha3_384_hash(const uint8_t* const __restrict, // input message
+                     const size_t,                    // input byte length
+                     uint8_t* const __restrict        // output digest
+  );
+
+  void sha3_512_hash(const uint8_t* const __restrict, // input message
                      const size_t,                    // input byte length
                      uint8_t* const __restrict        // output digest
   );
@@ -60,5 +66,16 @@ extern "C"
   )
   {
     sha3_384::hash(in, ilen, out);
+  }
+
+  // Given N (>=0) -bytes input message, this routines computes 64 -bytes output
+  // digest, using SHA3-512 hashing algorithm
+  void sha3_512_hash(
+    const uint8_t* const __restrict in, // input message
+    const size_t ilen,                  // len(in) | >= 0
+    uint8_t* const __restrict out       // 64 -bytes digest, to be computed
+  )
+  {
+    sha3_512::hash(in, ilen, out);
   }
 }

--- a/wrapper/sha3.cpp
+++ b/wrapper/sha3.cpp
@@ -1,5 +1,6 @@
 #include "sha3_224.hpp"
 #include "sha3_256.hpp"
+#include "sha3_384.hpp"
 
 // Thin C wrapper on top of underlying C++ implementation of SHA3 hash functions
 // and XOFs, which can be used for producing shared library object with
@@ -14,6 +15,11 @@ extern "C"
   );
 
   void sha3_256_hash(const uint8_t* const __restrict, // input message
+                     const size_t,                    // input byte length
+                     uint8_t* const __restrict        // output digest
+  );
+
+  void sha3_384_hash(const uint8_t* const __restrict, // input message
                      const size_t,                    // input byte length
                      uint8_t* const __restrict        // output digest
   );
@@ -43,5 +49,16 @@ extern "C"
   )
   {
     sha3_256::hash(in, ilen, out);
+  }
+
+  // Given N (>=0) -bytes input message, this routines computes 48 -bytes output
+  // digest, using SHA3-384 hashing algorithm
+  void sha3_384_hash(
+    const uint8_t* const __restrict in, // input message
+    const size_t ilen,                  // len(in) | >= 0
+    uint8_t* const __restrict out       // 48 -bytes digest, to be computed
+  )
+  {
+    sha3_384::hash(in, ilen, out);
   }
 }


### PR DESCRIPTION
- [x] Implement SHA3-512 hash function
- [x] Test functional correctness of it, using Python wrapper interface & Python `hashlib` module
- [x] Benchmark implementation on CPU system, using `google-benchmark`

```fish
2022-09-15T12:16:32+04:00
Running ./bench/a.out
Run on (8 X 2400 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB
  L1 Instruction 32 KiB
  L2 Unified 256 KiB (x4)
  L3 Unified 6144 KiB
Load Average: 1.61, 1.81, 2.11
------------------------------------------------------------------------------------
Benchmark                          Time             CPU   Iterations UserCounters...
------------------------------------------------------------------------------------
bench_sha3::sha3_512/32          374 ns          370 ns      1829955 bytes_per_second=82.4905M/s
bench_sha3::sha3_512/64          366 ns          362 ns      1918854 bytes_per_second=168.464M/s
bench_sha3::sha3_512/128         733 ns          725 ns       967760 bytes_per_second=168.324M/s
bench_sha3::sha3_512/256        1445 ns         1429 ns       482100 bytes_per_second=170.822M/s
bench_sha3::sha3_512/512        2891 ns         2860 ns       247557 bytes_per_second=170.714M/s
bench_sha3::sha3_512/1024       5379 ns         5322 ns       130929 bytes_per_second=183.509M/s
bench_sha3::sha3_512/2048      10393 ns        10297 ns        67645 bytes_per_second=189.679M/s
bench_sha3::sha3_512/4096      20302 ns        20087 ns        34492 bytes_per_second=194.466M/s
```