### PR TITLE
SHAKE{128, 256} Incremental Hashing API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,19 @@ CXXFLAGS = -std=c++20 -Wall -Wextra -pedantic
 OPTFLAGS = -O3 -march=native
 IFLAGS = -I ./include
 
-all: test
+all: tests
 
 wrapper/libsha3.so: wrapper/sha3.cpp include/*.hpp
 	$(CXX) $(CXXFLAGS) $(OPTFLAGS) $(IFLAGS) -fPIC --shared $< -o $@
 
 lib: wrapper/libsha3.so
 
-test: lib
+test/a.out: test/main.cpp include/*.hpp
+	$(CXX) $(CXXFLAGS) $(OPTFLAGS) $(IFLAGS) $< -o $@
+
+tests: lib test/a.out
 	cd wrapper/python; python3 -m pytest -v; cd ..
+	./test/a.out
 
 benchpy: lib
 	cd wrapper/python; python3 -m pytest -k bench -v; cd ..

--- a/include/shake128.hpp
+++ b/include/shake128.hpp
@@ -13,12 +13,15 @@ constexpr size_t rate = 1600 - capacity;
 //
 // See SHA3 extendable output function definition in section 6.2 of SHA3
 // specification https://dx.doi.org/10.6028/NIST.FIPS.202
+template<const bool incremental = false>
 struct shake128
 {
 private:
   uint64_t state[25];
   bool absorbed = false;
   size_t readable = 0;
+  size_t offset = 0;
+  size_t abytes = 0;
 
 public:
   // Given N -bytes input message, this routine consumes it into keccak[256]
@@ -26,7 +29,8 @@ public:
   //
   // Once you call this function on some object, calling it again doesn't do
   // anything !
-  void hash(const uint8_t* const __restrict msg, const size_t mlen)
+  void hash(const uint8_t* const __restrict msg,
+            const size_t mlen) requires(!incremental)
   {
     if (!absorbed) {
       sponge::absorb<0b00001111, 4, rate>(state, msg, mlen);
@@ -36,15 +40,166 @@ public:
     }
   }
 
+  // Given N -many bytes input message, this routine consumes those into
+  // keccak[256] sponge state
+  //
+  // Note, this routine can be called arbitrary number of times, each time with
+  // arbitrary bytes of input message, until keccak[256] state is finalized ( by
+  // calling routine with similar name ).
+  //
+  // This function is only enabled, when you decide to use SHAKE128 in
+  // incremental mode ( compile-time decision ). By default one uses SHAKE128
+  // API in non-incremental mode.
+  void absorb(const uint8_t* const __restrict msg,
+              const size_t mlen) requires(incremental)
+  {
+    constexpr size_t rbytes = rate >> 3;   // # -of bytes
+    constexpr size_t rwords = rbytes >> 3; // # -of 64 -bit words
+
+    if (!absorbed) {
+      uint8_t blk_bytes[rbytes]{};
+      uint64_t blk_words[rwords]{};
+
+      const size_t blk_cnt = (offset + mlen) / rbytes;
+      size_t moff = 0;
+
+      for (size_t i = 0; i < blk_cnt; i++) {
+        std::memcpy(blk_bytes + offset, msg + moff, rbytes - offset);
+
+        if constexpr (std::endian::native == std::endian::little) {
+          std::memcpy(blk_words, blk_bytes, rbytes);
+        } else {
+          for (size_t j = 0; j < rwords; j++) {
+            const size_t boff = j << 3;
+            blk_words[j] = (static_cast<uint64_t>(blk_bytes[boff ^ 7]) << 56) |
+                           (static_cast<uint64_t>(blk_bytes[boff ^ 6]) << 48) |
+                           (static_cast<uint64_t>(blk_bytes[boff ^ 5]) << 40) |
+                           (static_cast<uint64_t>(blk_bytes[boff ^ 4]) << 32) |
+                           (static_cast<uint64_t>(blk_bytes[boff ^ 3]) << 24) |
+                           (static_cast<uint64_t>(blk_bytes[boff ^ 2]) << 16) |
+                           (static_cast<uint64_t>(blk_bytes[boff ^ 1]) << 8) |
+                           (static_cast<uint64_t>(blk_bytes[boff ^ 0]) << 0);
+          }
+        }
+
+        for (size_t j = 0; j < rwords; j++) {
+          state[j] ^= blk_words[j];
+        }
+
+        moff += (rbytes - offset);
+        offset += (rbytes - offset);
+
+        keccak::permute(state);
+        offset %= rbytes;
+      }
+
+      const size_t rm_bytes = mlen - moff;
+
+      std::memset(blk_bytes, 0, rbytes);
+      std::memcpy(blk_bytes + offset, msg + moff, rm_bytes);
+
+      if constexpr (std::endian::native == std::endian::little) {
+        std::memcpy(blk_words, blk_bytes, rbytes);
+      } else {
+        for (size_t i = 0; i < rwords; i++) {
+          const size_t boff = i << 3;
+          blk_words[i] = (static_cast<uint64_t>(blk_bytes[boff ^ 7]) << 56) |
+                         (static_cast<uint64_t>(blk_bytes[boff ^ 6]) << 48) |
+                         (static_cast<uint64_t>(blk_bytes[boff ^ 5]) << 40) |
+                         (static_cast<uint64_t>(blk_bytes[boff ^ 4]) << 32) |
+                         (static_cast<uint64_t>(blk_bytes[boff ^ 3]) << 24) |
+                         (static_cast<uint64_t>(blk_bytes[boff ^ 2]) << 16) |
+                         (static_cast<uint64_t>(blk_bytes[boff ^ 1]) << 8) |
+                         (static_cast<uint64_t>(blk_bytes[boff ^ 0]) << 0);
+        }
+      }
+
+      for (size_t i = 0; i < rwords; i++) {
+        state[i] ^= blk_words[i];
+      }
+
+      offset += rm_bytes;
+
+      if (offset == rbytes) {
+        keccak::permute(state);
+        offset %= rbytes;
+      }
+
+      abytes += mlen;
+    }
+  }
+
+  // After consuming N -many bytes ( by invoking absorb routine arbitrary many
+  // times, each time with arbitrary input bytes ), this routine is invoked when
+  // no more input bytes remaining to be consumed by keccak[256] state.
+  //
+  // Note, once this routine is called, calling absorb() or finalize() again, on
+  // same SHAKE128 object, doesn't do anything. After finalization, one might
+  // intend to read arbitrary many bytes by squeezing sponge, which is done by
+  // calling read() function, as many times required.
+  //
+  // This function is only enabled, when you decide to use SHAKE128 in
+  // incremental mode ( compile-time decision ). By default one uses SHAKE128
+  // API in non-incremental mode.
+  void finalize() requires(incremental)
+  {
+    constexpr size_t rbytes = rate >> 3;   // # -of bytes
+    constexpr size_t rwords = rbytes >> 3; // # -of 64 -bit words
+
+    if (!absorbed) {
+      uint8_t pad[rbytes]{};
+      uint8_t blk_bytes[rbytes]{};
+      uint64_t blk_words[rwords]{};
+
+      const size_t mblen = abytes << 3;
+      const size_t tot_mblen = mblen + 4;
+      const size_t plen = sponge::pad101<0b00001111, 4, rate>(tot_mblen, pad);
+      const size_t read = (plen + 4) >> 3; // in bytes
+
+      std::memcpy(blk_bytes + offset, pad, read);
+
+      if constexpr (std::endian::native == std::endian::little) {
+        std::memcpy(blk_words, blk_bytes, rbytes);
+      } else {
+        for (size_t i = 0; i < rwords; i++) {
+          const size_t boff = i << 3;
+          blk_words[i] = (static_cast<uint64_t>(blk_bytes[boff ^ 7]) << 56) |
+                         (static_cast<uint64_t>(blk_bytes[boff ^ 6]) << 48) |
+                         (static_cast<uint64_t>(blk_bytes[boff ^ 5]) << 40) |
+                         (static_cast<uint64_t>(blk_bytes[boff ^ 4]) << 32) |
+                         (static_cast<uint64_t>(blk_bytes[boff ^ 3]) << 24) |
+                         (static_cast<uint64_t>(blk_bytes[boff ^ 2]) << 16) |
+                         (static_cast<uint64_t>(blk_bytes[boff ^ 1]) << 8) |
+                         (static_cast<uint64_t>(blk_bytes[boff ^ 0]) << 0);
+        }
+      }
+
+      for (size_t i = 0; i < rwords; i++) {
+        state[i] ^= blk_words[i];
+      }
+
+      offset += read;
+
+      if (offset == rbytes) {
+        keccak::permute(state);
+        offset %= rbytes;
+      }
+
+      absorbed = true;
+      readable = rate >> 3;
+    }
+  }
+
   // Given that N -bytes input message is already absorbed into sponge state
-  // using `hash( ... )` routine, this routine is used for squeezing M -bytes
-  // out of consumable part of state ( i.e. rate portion of state )
+  // using `hash( ... )`/ `absorb(...)` & `finalize(...)` routine, this routine
+  // is used for squeezing M -bytes out of consumable part of state ( i.e. rate
+  // portion of state )
   //
   // This routine can be used for squeezing arbitrary number of bytes from
   // sponge keccak[256]
   //
-  // Make sure you absorb ( see hash(...) routine ) message bytes first, then
-  // only call this function, otherwise it can't squeeze out anything.
+  // Make sure you absorb message bytes first, then only call this function,
+  // otherwise it can't squeeze out anything.
   void read(uint8_t* const __restrict dig, const size_t dlen)
   {
     if (!absorbed) {

--- a/include/shake256.hpp
+++ b/include/shake256.hpp
@@ -13,12 +13,15 @@ constexpr size_t rate = 1600 - capacity;
 //
 // See SHA3 extendable output function definition in section 6.2 of SHA3
 // specification https://dx.doi.org/10.6028/NIST.FIPS.202
+template<const bool incremental = false>
 struct shake256
 {
 private:
   uint64_t state[25];
   bool absorbed = false;
   size_t readable = 0;
+  size_t offset = 0;
+  size_t abytes = 0;
 
 public:
   // Given N -bytes input message, this routine consumes it into keccak[512]
@@ -26,10 +29,161 @@ public:
   //
   // Once you call this function on some object, calling it again doesn't do
   // anything !
-  void hash(const uint8_t* const __restrict msg, const size_t mlen)
+  void hash(const uint8_t* const __restrict msg,
+            const size_t mlen) requires(!incremental)
   {
     if (!absorbed) {
       sponge::absorb<0b00001111, 4, rate>(state, msg, mlen);
+
+      absorbed = true;
+      readable = rate >> 3;
+    }
+  }
+
+  // Given N -many bytes input message, this routine consumes those into
+  // keccak[512] sponge state
+  //
+  // Note, this routine can be called arbitrary number of times, each time with
+  // arbitrary bytes of input message, until keccak[512] state is finalized ( by
+  // calling routine with similar name ).
+  //
+  // This function is only enabled, when you decide to use SHAKE256 in
+  // incremental mode ( compile-time decision ). By default one uses SHAKE256
+  // API in non-incremental mode.
+  void absorb(const uint8_t* const __restrict msg,
+              const size_t mlen) requires(incremental)
+  {
+    constexpr size_t rbytes = rate >> 3;   // # -of bytes
+    constexpr size_t rwords = rbytes >> 3; // # -of 64 -bit words
+
+    if (!absorbed) {
+      uint8_t blk_bytes[rbytes]{};
+      uint64_t blk_words[rwords]{};
+
+      const size_t blk_cnt = (offset + mlen) / rbytes;
+      size_t moff = 0;
+
+      for (size_t i = 0; i < blk_cnt; i++) {
+        std::memcpy(blk_bytes + offset, msg + moff, rbytes - offset);
+
+        if constexpr (std::endian::native == std::endian::little) {
+          std::memcpy(blk_words, blk_bytes, rbytes);
+        } else {
+          for (size_t j = 0; j < rwords; j++) {
+            const size_t boff = j << 3;
+            blk_words[j] = (static_cast<uint64_t>(blk_bytes[boff ^ 7]) << 56) |
+                           (static_cast<uint64_t>(blk_bytes[boff ^ 6]) << 48) |
+                           (static_cast<uint64_t>(blk_bytes[boff ^ 5]) << 40) |
+                           (static_cast<uint64_t>(blk_bytes[boff ^ 4]) << 32) |
+                           (static_cast<uint64_t>(blk_bytes[boff ^ 3]) << 24) |
+                           (static_cast<uint64_t>(blk_bytes[boff ^ 2]) << 16) |
+                           (static_cast<uint64_t>(blk_bytes[boff ^ 1]) << 8) |
+                           (static_cast<uint64_t>(blk_bytes[boff ^ 0]) << 0);
+          }
+        }
+
+        for (size_t j = 0; j < rwords; j++) {
+          state[j] ^= blk_words[j];
+        }
+
+        moff += (rbytes - offset);
+        offset += (rbytes - offset);
+
+        keccak::permute(state);
+        offset %= rbytes;
+      }
+
+      const size_t rm_bytes = mlen - moff;
+
+      std::memset(blk_bytes, 0, rbytes);
+      std::memcpy(blk_bytes + offset, msg + moff, rm_bytes);
+
+      if constexpr (std::endian::native == std::endian::little) {
+        std::memcpy(blk_words, blk_bytes, rbytes);
+      } else {
+        for (size_t i = 0; i < rwords; i++) {
+          const size_t boff = i << 3;
+          blk_words[i] = (static_cast<uint64_t>(blk_bytes[boff ^ 7]) << 56) |
+                         (static_cast<uint64_t>(blk_bytes[boff ^ 6]) << 48) |
+                         (static_cast<uint64_t>(blk_bytes[boff ^ 5]) << 40) |
+                         (static_cast<uint64_t>(blk_bytes[boff ^ 4]) << 32) |
+                         (static_cast<uint64_t>(blk_bytes[boff ^ 3]) << 24) |
+                         (static_cast<uint64_t>(blk_bytes[boff ^ 2]) << 16) |
+                         (static_cast<uint64_t>(blk_bytes[boff ^ 1]) << 8) |
+                         (static_cast<uint64_t>(blk_bytes[boff ^ 0]) << 0);
+        }
+      }
+
+      for (size_t i = 0; i < rwords; i++) {
+        state[i] ^= blk_words[i];
+      }
+
+      offset += rm_bytes;
+
+      if (offset == rbytes) {
+        keccak::permute(state);
+        offset %= rbytes;
+      }
+
+      abytes += mlen;
+    }
+  }
+
+  // After consuming N -many bytes ( by invoking absorb routine arbitrary many
+  // times, each time with arbitrary input bytes ), this routine is invoked when
+  // no more input bytes remaining to be consumed by keccak[512] state.
+  //
+  // Note, once this routine is called, calling absorb() or finalize() again, on
+  // same SHAKE256 object, doesn't do anything. After finalization, one might
+  // intend to read arbitrary many bytes by squeezing sponge, which is done by
+  // calling read() function, as many times required.
+  //
+  // This function is only enabled, when you decide to use SHAKE256 in
+  // incremental mode ( compile-time decision ). By default one uses SHAKE256
+  // API in non-incremental mode.
+  void finalize() requires(incremental)
+  {
+    constexpr size_t rbytes = rate >> 3;   // # -of bytes
+    constexpr size_t rwords = rbytes >> 3; // # -of 64 -bit words
+
+    if (!absorbed) {
+      uint8_t pad[rbytes]{};
+      uint8_t blk_bytes[rbytes]{};
+      uint64_t blk_words[rwords]{};
+
+      const size_t mblen = abytes << 3;
+      const size_t tot_mblen = mblen + 4;
+      const size_t plen = sponge::pad101<0b00001111, 4, rate>(tot_mblen, pad);
+      const size_t read = (plen + 4) >> 3; // in bytes
+
+      std::memcpy(blk_bytes + offset, pad, read);
+
+      if constexpr (std::endian::native == std::endian::little) {
+        std::memcpy(blk_words, blk_bytes, rbytes);
+      } else {
+        for (size_t i = 0; i < rwords; i++) {
+          const size_t boff = i << 3;
+          blk_words[i] = (static_cast<uint64_t>(blk_bytes[boff ^ 7]) << 56) |
+                         (static_cast<uint64_t>(blk_bytes[boff ^ 6]) << 48) |
+                         (static_cast<uint64_t>(blk_bytes[boff ^ 5]) << 40) |
+                         (static_cast<uint64_t>(blk_bytes[boff ^ 4]) << 32) |
+                         (static_cast<uint64_t>(blk_bytes[boff ^ 3]) << 24) |
+                         (static_cast<uint64_t>(blk_bytes[boff ^ 2]) << 16) |
+                         (static_cast<uint64_t>(blk_bytes[boff ^ 1]) << 8) |
+                         (static_cast<uint64_t>(blk_bytes[boff ^ 0]) << 0);
+        }
+      }
+
+      for (size_t i = 0; i < rwords; i++) {
+        state[i] ^= blk_words[i];
+      }
+
+      offset += read;
+
+      if (offset == rbytes) {
+        keccak::permute(state);
+        offset %= rbytes;
+      }
 
       absorbed = true;
       readable = rate >> 3;

--- a/include/test_shake128.hpp
+++ b/include/test_shake128.hpp
@@ -1,0 +1,55 @@
+#pragma once
+#include "shake128.hpp"
+#include "utils.hpp"
+#include <cassert>
+
+// Test SHA3 Extendable-Output Functions
+namespace test_sha3 {
+
+// Test that hashing same message bytes using both incremental and one-shot
+// hashing APIs, should yield same output bytes.
+template<const size_t m0len, const size_t m1len>
+static void
+test_shake128()
+{
+  constexpr size_t mlen = m0len + m1len;
+  constexpr size_t dlen = 32;
+
+  uint8_t* msg0 = static_cast<uint8_t*>(std::malloc(m0len));
+  uint8_t* msg1 = static_cast<uint8_t*>(std::malloc(m1len));
+  uint8_t* msg = static_cast<uint8_t*>(std::malloc(mlen));
+  uint8_t* dig0 = static_cast<uint8_t*>(std::malloc(dlen));
+  uint8_t* dig1 = static_cast<uint8_t*>(std::malloc(dlen));
+
+  random_data<uint8_t>(msg0, m0len);
+  random_data<uint8_t>(msg1, m1len);
+  std::memcpy(msg + 0, msg0, m0len);
+  std::memcpy(msg + m0len, msg1, m1len);
+
+  // Oneshot Hashing
+  shake128::shake128 hasher0{};
+  hasher0.hash(msg, mlen);
+  hasher0.read(dig0, dlen);
+
+  // Incremental Hashing
+  shake128::shake128<true> hasher1{};
+  hasher1.absorb(msg0, m0len);
+  hasher1.absorb(msg1, m1len);
+  hasher1.finalize();
+  hasher1.read(dig1, dlen);
+
+  bool flg = false;
+  for (size_t i = 0; i < dlen; i++) {
+    flg |= static_cast<bool>(dig0[i] ^ dig1[i]);
+  }
+
+  std::free(msg0);
+  std::free(msg1);
+  std::free(msg);
+  std::free(dig0);
+  std::free(dig1);
+
+  assert(!flg);
+}
+
+}

--- a/include/test_shake256.hpp
+++ b/include/test_shake256.hpp
@@ -1,0 +1,55 @@
+#pragma once
+#include "shake256.hpp"
+#include "utils.hpp"
+#include <cassert>
+
+// Test SHA3 Extendable-Output Functions
+namespace test_sha3 {
+
+// Test that hashing same message bytes using both incremental and one-shot
+// hashing APIs, should yield same output bytes.
+template<const size_t m0len, const size_t m1len>
+static void
+test_shake256()
+{
+  constexpr size_t mlen = m0len + m1len;
+  constexpr size_t dlen = 64;
+
+  uint8_t* msg0 = static_cast<uint8_t*>(std::malloc(m0len));
+  uint8_t* msg1 = static_cast<uint8_t*>(std::malloc(m1len));
+  uint8_t* msg = static_cast<uint8_t*>(std::malloc(mlen));
+  uint8_t* dig0 = static_cast<uint8_t*>(std::malloc(dlen));
+  uint8_t* dig1 = static_cast<uint8_t*>(std::malloc(dlen));
+
+  random_data<uint8_t>(msg0, m0len);
+  random_data<uint8_t>(msg1, m1len);
+  std::memcpy(msg + 0, msg0, m0len);
+  std::memcpy(msg + m0len, msg1, m1len);
+
+  // Oneshot Hashing
+  shake256::shake256 hasher0{};
+  hasher0.hash(msg, mlen);
+  hasher0.read(dig0, dlen);
+
+  // Incremental Hashing
+  shake256::shake256<true> hasher1{};
+  hasher1.absorb(msg0, m0len);
+  hasher1.absorb(msg1, m1len);
+  hasher1.finalize();
+  hasher1.read(dig1, dlen);
+
+  bool flg = false;
+  for (size_t i = 0; i < dlen; i++) {
+    flg |= static_cast<bool>(dig0[i] ^ dig1[i]);
+  }
+
+  std::free(msg0);
+  std::free(msg1);
+  std::free(msg);
+  std::free(dig0);
+  std::free(dig1);
+
+  assert(!flg);
+}
+
+}

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,0 +1,20 @@
+#include "test_shake128.hpp"
+#include <iostream>
+
+int
+main()
+{
+  constexpr size_t shake128_rate = shake128::rate >> 3;
+
+  test_sha3::test_shake128<0, shake128_rate>();
+  test_sha3::test_shake128<1, shake128_rate>();
+  test_sha3::test_shake128<1, shake128_rate - 1>();
+  test_sha3::test_shake128<2, shake128_rate - 2>();
+  test_sha3::test_shake128<2, shake128_rate - 1>();
+  test_sha3::test_shake128<shake128_rate - 1, 1>();
+  test_sha3::test_shake128<shake128_rate - 2, 2>();
+  test_sha3::test_shake128<shake128_rate - 1, 2>();
+  std::cout << "[test] SHAKE128 incremental hashing\n";
+
+  return EXIT_SUCCESS;
+}

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,10 +1,12 @@
 #include "test_shake128.hpp"
+#include "test_shake256.hpp"
 #include <iostream>
 
 int
 main()
 {
   constexpr size_t shake128_rate = shake128::rate >> 3;
+  constexpr size_t shake256_rate = shake256::rate >> 3;
 
   test_sha3::test_shake128<0, shake128_rate>();
   test_sha3::test_shake128<1, shake128_rate>();
@@ -15,6 +17,16 @@ main()
   test_sha3::test_shake128<shake128_rate - 2, 2>();
   test_sha3::test_shake128<shake128_rate - 1, 2>();
   std::cout << "[test] SHAKE128 incremental hashing\n";
+
+  test_sha3::test_shake256<0, shake256_rate>();
+  test_sha3::test_shake256<1, shake256_rate>();
+  test_sha3::test_shake256<1, shake256_rate - 1>();
+  test_sha3::test_shake256<2, shake256_rate - 2>();
+  test_sha3::test_shake256<2, shake256_rate - 1>();
+  test_sha3::test_shake256<shake256_rate - 1, 1>();
+  test_sha3::test_shake256<shake256_rate - 2, 2>();
+  test_sha3::test_shake256<shake256_rate - 1, 2>();
+  std::cout << "[test] SHAKE256 incremental hashing\n";
 
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
- [x] Add support for incremental absorption of input message bytes into keccak[256] ( or keccak[512] ) state
- [x] Test functional correctness of API implementation ( against one-shot hashing API )

For testing, issue

```bash
make
```

New incremental hashing API can be used like

```cpp
#include "shake256.hpp"

uint8 msg0[32]{ ... };  // message 0
uint8 msg1[1]{ ... };   // message 1
uint8 msg2[31]{ ... };  // message 2

uint8_t dig[64]{}; // output digest

shake256::shake256<true> hasher{}; // template parameter `true` - enabling incremental hashing API

hasher.absorb(msg0, sizeof(msg0));
hasher.absorb(msg1, sizeof(msg1));
hasher.absorb(msg2, sizeof(msg2));
hasher.finalize();

hasher.read(dig, sizeof(dig));
```

> **Note**
> I suggest you to look at test functions for [SHAKE128](https://github.com/itzmeanjan/sha3/blob/5091c5c71cae623cc17d98fe01a89167693e1223/include/test_shake128.hpp) & [SHAKE256](https://github.com/itzmeanjan/sha3/blob/5091c5c71cae623cc17d98fe01a89167693e1223/include/test_shake256.hpp).