### PR TITLE
Minor Optimization in `θ` Step Mapping Function

### DIFF
--- a/include/keccak.hpp
+++ b/include/keccak.hpp
@@ -107,15 +107,15 @@ constexpr uint64_t RC[ROUNDS]{ compute_rc(0),  compute_rc(1),  compute_rc(2),
 inline static void
 theta(uint64_t* const state)
 {
-  uint64_t c[5];
+  uint64_t c[5]{};
   uint64_t d[5];
 
-  for (size_t i = 0; i < 5; i++) {
-    const uint64_t t0 = state[i] ^ state[i + 5];
-    const uint64_t t1 = state[i + 10] ^ state[i + 15];
-    const uint64_t t2 = t0 ^ t1 ^ state[i + 20];
-
-    c[i] = t2;
+  for (size_t i = 0; i < 25; i += 5) {
+    c[0] ^= state[i + 0];
+    c[1] ^= state[i + 1];
+    c[2] ^= state[i + 2];
+    c[3] ^= state[i + 3];
+    c[4] ^= state[i + 4];
   }
 
   for (size_t i = 0; i < 5; i++) {

--- a/include/shake128.hpp
+++ b/include/shake128.hpp
@@ -29,8 +29,8 @@ public:
   //
   // Once you call this function on some object, calling it again doesn't do
   // anything !
-  void hash(const uint8_t* const __restrict msg,
-            const size_t mlen) requires(!incremental)
+  void hash(const uint8_t* const __restrict msg, const size_t mlen)
+    requires(!incremental)
   {
     if (!absorbed) {
       sponge::absorb<0b00001111, 4, rate>(state, msg, mlen);
@@ -50,8 +50,8 @@ public:
   // This function is only enabled, when you decide to use SHAKE128 in
   // incremental mode ( compile-time decision ). By default one uses SHAKE128
   // API in non-incremental mode.
-  void absorb(const uint8_t* const __restrict msg,
-              const size_t mlen) requires(incremental)
+  void absorb(const uint8_t* const __restrict msg, const size_t mlen)
+    requires(incremental)
   {
     constexpr size_t rbytes = rate >> 3;   // # -of bytes
     constexpr size_t rwords = rbytes >> 3; // # -of 64 -bit words
@@ -141,7 +141,8 @@ public:
   // This function is only enabled, when you decide to use SHAKE128 in
   // incremental mode ( compile-time decision ). By default one uses SHAKE128
   // API in non-incremental mode.
-  void finalize() requires(incremental)
+  void finalize()
+    requires(incremental)
   {
     constexpr size_t rbytes = rate >> 3;   // # -of bytes
     constexpr size_t rwords = rbytes >> 3; // # -of 64 -bit words

--- a/include/shake256.hpp
+++ b/include/shake256.hpp
@@ -29,8 +29,8 @@ public:
   //
   // Once you call this function on some object, calling it again doesn't do
   // anything !
-  void hash(const uint8_t* const __restrict msg,
-            const size_t mlen) requires(!incremental)
+  void hash(const uint8_t* const __restrict msg, const size_t mlen)
+    requires(!incremental)
   {
     if (!absorbed) {
       sponge::absorb<0b00001111, 4, rate>(state, msg, mlen);
@@ -50,8 +50,8 @@ public:
   // This function is only enabled, when you decide to use SHAKE256 in
   // incremental mode ( compile-time decision ). By default one uses SHAKE256
   // API in non-incremental mode.
-  void absorb(const uint8_t* const __restrict msg,
-              const size_t mlen) requires(incremental)
+  void absorb(const uint8_t* const __restrict msg, const size_t mlen)
+    requires(incremental)
   {
     constexpr size_t rbytes = rate >> 3;   // # -of bytes
     constexpr size_t rwords = rbytes >> 3; // # -of 64 -bit words
@@ -141,7 +141,8 @@ public:
   // This function is only enabled, when you decide to use SHAKE256 in
   // incremental mode ( compile-time decision ). By default one uses SHAKE256
   // API in non-incremental mode.
-  void finalize() requires(incremental)
+  void finalize()
+    requires(incremental)
   {
     constexpr size_t rbytes = rate >> 3;   // # -of bytes
     constexpr size_t rwords = rbytes >> 3; // # -of 64 -bit words

--- a/include/sponge.hpp
+++ b/include/sponge.hpp
@@ -31,8 +31,8 @@ check_domain_seperator(const size_t dom_sep_bit_len)
 // https://dx.doi.org/10.6028/NIST.FIPS.202
 template<const uint8_t dom_sep, const size_t bits, const size_t rate>
 static size_t
-pad101(const size_t mlen,
-       uint8_t* const pad) requires(check_domain_seperator(bits))
+pad101(const size_t mlen, uint8_t* const pad)
+  requires(check_domain_seperator(bits))
 {
   const size_t j = rate - (mlen + 2ul) % rate;
   const bool flg = j <= (6ul - bits);
@@ -63,7 +63,8 @@ get_msg_blk(
   const size_t plen,                   // in bits
   uint8_t* const __restrict blk,       // extracted block
   const size_t blk_idx                 // index of block to extract
-  ) requires(check_domain_seperator(bits))
+  )
+  requires(check_domain_seperator(bits))
 {
   const size_t mblen = mlen << 3;             // in bits | < first segment >
   const size_t tot_mblen = mblen + bits;      // in bits | < middle segment >
@@ -101,7 +102,8 @@ template<const uint8_t dom_sep, const size_t bits, const size_t rate>
 static void
 absorb(uint64_t* const __restrict state,
        const uint8_t* const __restrict msg,
-       const size_t mlen) requires(check_domain_seperator(bits))
+       const size_t mlen)
+  requires(check_domain_seperator(bits))
 {
   const size_t mblen = mlen << 3;        // in bits
   const size_t tot_mblen = mblen + bits; // in bits

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -9,7 +9,8 @@
 // Generates N -many random values of type T | N >= 0
 template<typename T>
 static inline void
-random_data(T* const data, const size_t len) requires(std::is_unsigned_v<T>)
+random_data(T* const data, const size_t len)
+  requires(std::is_unsigned_v<T>)
 {
   std::random_device rd;
   std::mt19937_64 gen(rd());


### PR DESCRIPTION
- [x] Access keccak state contiguously when computing `θ` step mapping function
- [x] Reformatted source with `clang-format`