### PR TITLE
`Keccak-p[1600, 24]` Permutation using AVX2 Intrinsics

### DIFF
--- a/.github/workflows/test_ci.yml
+++ b/.github/workflows/test_ci.yml
@@ -17,7 +17,11 @@ jobs:
       run: sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10; sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 9
     - name: Install Python Dependencies
       run: python3 -m pip install -r wrapper/python/requirements.txt --user
-    - name: Execute Tests
+    - name: Execute Tests ( without AVX2 )
       run: make
+    - name: Cleanup
+      run: make clean
+    - name: Execute Tests ( with AVX2 )
+      run: AVX2=1 make # If AVX2 is not available on target CPU, uses scalar implementation
     - name: Cleanup
       run: make clean

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ clean:
 	find . -name '*.out' -o -name '*.o' -o -name '*.so' -o -name '*.gch' | xargs rm -rf
 
 format:
-	find . -name '*.cpp' -o -name '*.hpp' | xargs clang-format -i --style="{BasedOnStyle: Mozilla, ColumnLimit: 100}" && python3 -m black wrapper/python/*.py
+	find . -name '*.cpp' -o -name '*.hpp' | xargs clang-format -i --style="{BasedOnStyle: Mozilla, ColumnLimit: 110}" && python3 -m black wrapper/python/*.py
 
 bench/a.out: bench/main.cpp include/*.hpp
 	# make sure you've google-benchmark globally installed;

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ clean:
 	find . -name '*.out' -o -name '*.o' -o -name '*.so' -o -name '*.gch' | xargs rm -rf
 
 format:
-	find . -name '*.cpp' -o -name '*.hpp' | xargs clang-format -i --style=Mozilla && python3 -m black wrapper/python/*.py
+	find . -name '*.cpp' -o -name '*.hpp' | xargs clang-format -i --style="{BasedOnStyle: Mozilla, ColumnLimit: 100}" && python3 -m black wrapper/python/*.py
 
 bench/a.out: bench/main.cpp include/*.hpp
 	# make sure you've google-benchmark globally installed;

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,18 @@
 CXX = g++
 CXXFLAGS = -std=c++20 -Wall -Wextra -pedantic
-OPTFLAGS = -O3 -march=native
+OPTFLAGS = -O3 -march=native -mtune=native
 IFLAGS = -I ./include
+DUSE_AVX2 = -DUSE_AVX2=$(or $(AVX2),0)
 
 all: tests
 
 wrapper/libsha3.so: wrapper/sha3.cpp include/*.hpp
-	$(CXX) $(CXXFLAGS) $(OPTFLAGS) $(IFLAGS) -fPIC --shared $< -o $@
+	$(CXX) $(CXXFLAGS) $(OPTFLAGS) $(IFLAGS) $(DUSE_AVX2) -fPIC --shared $< -o $@
 
 lib: wrapper/libsha3.so
 
 test/a.out: test/main.cpp include/*.hpp
-	$(CXX) $(CXXFLAGS) $(OPTFLAGS) $(IFLAGS) $< -o $@
+	$(CXX) $(CXXFLAGS) $(OPTFLAGS) $(IFLAGS) $(DUSE_AVX2) $< -o $@
 
 tests: lib test/a.out
 	cd wrapper/python; python3 -m pytest -v; cd ..
@@ -29,7 +30,7 @@ format:
 bench/a.out: bench/main.cpp include/*.hpp
 	# make sure you've google-benchmark globally installed;
 	# see https://github.com/google/benchmark/tree/60b16f1#installation
-	$(CXX) $(CXXFLAGS) $(OPTFLAGS) $(IFLAGS) $< -lbenchmark -o $@
+	$(CXX) $(CXXFLAGS) $(OPTFLAGS) $(IFLAGS) $(DUSE_AVX2) $< -lbenchmark -o $@
 
 benchmark: bench/a.out
 	./$< --benchmark_counters_tabular=true

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ SHA3: Permutation-Based Hash and Extendable-Output Functions
 
 SHA3 standard by NIST specifies four permutation-based hash functions and two extendable-output functions, which are built on top of keccak-p[1600, 24] permutation.
 
-These hash functions and extendable output functions are pretty commonly used in various post-quantum cryptography algorithms ( those used for public key encryption, key establishment mechanism & digital signature generation ) i.e. some of which are already declared as selected candidates ( e.g. Kyber, Falcon, Dilithium etc. ) of NIST PQC standardization effort or some are still competing ( e.g. Bike, Classic McEliece etc. ) in final round of standardization. This is exactly why I decided to implement SHA3 specification as **zero-dependency, header-only and easy-to-use C++ library**.
+These hash functions and extendable output functions are pretty commonly used in various post-quantum cryptography algorithms ( those used for public key encryption, key establishment mechanism & digital signature generation ) i.e. some of which are already declared as selected candidates ( e.g. Kyber, Falcon, Dilithium, SPHINCS+ etc. ) of NIST PQC standardization effort or some are still competing ( e.g. Bike, Classic McEliece etc. ) in final round of standardization. This is exactly why I decided to implement SHA3 specification as **zero-dependency, header-only and easy-to-use C++ library**.
 
 > **Note**
 > `sha3` - this project will be used in various post-quantum cryptographic algorithm implementations which are already selected or will be selected by NIST.
@@ -14,6 +14,7 @@ Few of those places, where I've already used `sha3` as ( git submodule based ) d
 
 - [Kyber: Post-Quantum Public-key Encryption & Key-establishment Algorithm](https://github.com/itzmeanjan/kyber)
 - [Dilithium: Post-Quantum Digital Signature Algorithm](https://github.com/itzmeanjan/dilithium)
+- [SPHINCS+: Stateless Hash-based Digital Signature Algorithm](https://github.com/itzmeanjan/sphincs)
 
 Here I'm maintaining a zero-dependency, header-only C++ library, using modern C++ features ( such as C++{11, 17, 20} ), which is fairly easy-to-use in your project, implementing SHA3 [specification](https://dx.doi.org/10.6028/NIST.FIPS.202) i.e. NIST FIPS PUB 202. Following algorithms are implemented in `sha3` library
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ SHA3: Permutation-Based Hash and Extendable-Output Functions
 
 ## Motivation
 
-SHA3 standard by NIST specifies four permutation-based hash functions and two extendable-output functions, which are built on top of keccak-p[1600, 24] permutation.
+SHA3 standard by NIST ( i.e. NIST FIPS PUB 202 ) specifies four permutation-based hash functions and two extendable-output functions, which are built on top of keccak-p[1600, 24] permutation.
 
-These hash functions and extendable output functions are pretty commonly used in various post-quantum cryptography algorithms ( those used for public key encryption, key establishment mechanism & digital signature generation ) i.e. some of which are already declared as selected candidates ( e.g. Kyber, Falcon, Dilithium, SPHINCS+ etc. ) of NIST PQC standardization effort or some are still competing ( e.g. Bike, Classic McEliece etc. ) in final round of standardization. This is exactly why I decided to implement SHA3 specification as **zero-dependency, header-only and easy-to-use C++ library**.
+These hash functions and extendable output functions are pretty commonly used in various post-quantum cryptography algorithms ( those used for public key encryption, key establishment mechanism & digital signature algorithms ) i.e. some of which are already declared as selected candidates ( e.g. Kyber, Falcon, Dilithium, SPHINCS+ etc. ) of NIST PQC standardization effort or some are still competing ( e.g. Bike, Classic McEliece etc. ) in final round of standardization. I decided to implement SHA3 specification as **zero-dependency, header-only and easy-to-use C++ library**, so that I can make use of it as modular dependency ( say pinned to specific commit using git submodule ) in other ( *future* ) projects.
 
 > **Note**
 > `sha3` - this project will be used in various post-quantum cryptographic algorithm implementations which are already selected or will be selected by NIST.
@@ -91,7 +91,13 @@ and check for their equality.
 Issue following command for running test cases
 
 ```fish
-make
+make       # by default USE_AVX2=0
+```
+
+If target CPU has AVX2 flag, this SHA3 implementation can make use of AVX2 intrinsics for keccak-p[1600, 24] permutation. All one needs to do is define `USE_AVX2` preprocessor constant with non-zero value, which is used in [keccak.hpp](./include/keccak.hpp) for determining whether to use AVX2 for keccak permutation or not. For testing functional correctness of AVX2 intrinsic based keccak permutation, you may issue
+
+```fish
+AVX2=1 make # trigger AVX2 based keccak permutation code compilation
 ```
 
 ## Benchmarking
@@ -105,6 +111,14 @@ Find micro-benchmarking ( using `google-benchmark` ) results [here](./bench).
 - Include proper header files ( select what you need by name )
 - Properly use API ( see usage examples/ test cases )
 - When compiling, let your compiler know where it can find respective header files
+
+> **Note**
+
+> When compiling you can ask your compiler to check if AVX2 is available on target CPU by issuing
+
+> $ `echo | g++ -march=native -dM -E -x c++ - | grep -i avx`
+
+> If AVX2 is available on target CPU and you want to make use of it for keccak-p[1600, 24] permutation, consider passing `-march=native -DUSE_AVX2=1` when compiling [include/keccak.hpp](./include/keccak.hpp). By default it won't trigger compilation of AVX2 intrinsic based code path, you've to explicitly ask for it.
 
 Hash Function | Header/ Namespace | Example
 --- | --- | --:
@@ -125,6 +139,7 @@ SHAKE256 ( explicit incremental consumption ) | [`shake256::`](./include/shake25
 
 ```fish
 $ g++ -std=c++20 -Wall -O3 -I include example/sha3_224.cpp && ./a.out
+$ g++ -std=c++20 -Wall -O3 -march=native -DUSE_AVX2=1 -I include example/sha3_224.cpp && ./a.out # for keccak with AVX2
 SHA3-224
 
 Input  : 043f0fa310343b6ca42c3d2ab6f168574fd41774d49c9c1e5922c2cd60b43dbb
@@ -133,6 +148,7 @@ Output : 3bfbd5e41e850f29daf9c08dbcaca7c43ca939e7d6c0b6d8993c6af4
 # ---
 
 $ g++ -std=c++20 -Wall -O3 -I include example/sha3_256.cpp && ./a.out
+$ g++ -std=c++20 -Wall -O3 -march=native -DUSE_AVX2=1 -I include example/sha3_256.cpp && ./a.out # for keccak with AVX2
 SHA3-256
 
 Input  : 70a3bf382218c7f4ae25775ab1d21f9d48e2f03af70dcdec790a338e982e6fa8
@@ -141,6 +157,7 @@ Output : 57be0ef9634da2d94219c53032809f4ffc145df6782279a8059afe607715d675
 # ---
 
 $ g++ -std=c++20 -Wall -O3 -I include example/sha3_384.cpp && ./a.out
+$ g++ -std=c++20 -Wall -O3 -march=native -DUSE_AVX2=1 -I include example/sha3_384.cpp && ./a.out # for keccak with AVX2
 SHA3-384
 
 Input  : 314686636dc0499f2ebf0a201fe2d44e2e8888ac1109939998230f2cba5d0e94
@@ -149,6 +166,7 @@ Output : 554f4506a1b73724d0ce25cc4a0c0b4fc26478cde43013a59c7e25a22e3e73fbcfa731f
 # ---
 
 $ g++ -std=c++20 -Wall -O3 -I include example/sha3_512.cpp && ./a.out
+$ g++ -std=c++20 -Wall -O3 -march=native -DUSE_AVX2=1 -I include example/sha3_512.cpp && ./a.out # for keccak with AVX2
 SHA3-512
 
 Input  : 2c3c0ae485204067f1ecbc69a8fefd19a94c9c1552158a8d57a6612b3202f373
@@ -156,7 +174,8 @@ Output : 578386bdd6eb816d6d0cbc984351c889f70675a2661ba605aa65ce204b88a6d6553946c
 
 # ---
 
-g++ -std=c++20 -Wall -O3 -I include example/shake128.cpp && ./a.out
+$ g++ -std=c++20 -Wall -O3 -I include example/shake128.cpp && ./a.out
+$ g++ -std=c++20 -Wall -O3 -march=native -DUSE_AVX2=1 -I include example/shake128.cpp && ./a.out # for keccak with AVX2
 SHAKE-128
 
 Input  : 8814e9f091cd4ee6ac6795be43b25b4d741143f4d7f7e9858731447359eaa1e8
@@ -164,7 +183,8 @@ Output : d32991406e38740f9b9b2674e59259891bfd23f9d6ea71a816c3133466163dacb3b1cef
 
 # ---
 
-g++ -std=c++20 -Wall -O3 -I include example/shake256.cpp && ./a.out
+$ g++ -std=c++20 -Wall -O3 -I include example/shake256.cpp && ./a.out
+$ g++ -std=c++20 -Wall -O3 -march=native -DUSE_AVX2=1 -I include example/shake256.cpp && ./a.out # for keccak with AVX2
 SHAKE-256
 
 Input  : a6506638e34127e0a8415241479c968c20422f46497663eaf244f205a756f0b3
@@ -172,7 +192,8 @@ Output : ce679163b642380365c3c11dcbca7a36ddd01cefba35b8ec18ad937268f584999c6e8ae
 
 # ---
 
-g++ -std=c++20 -Wall -O3 -I include example/incremental_shake128.cpp && ./a.out
+$ g++ -std=c++20 -Wall -O3 -I include example/incremental_shake128.cpp && ./a.out
+$ g++ -std=c++20 -Wall -O3 -march=native -DUSE_AVX2=1 -I include example/incremental_shake128.cpp && ./a.out # for keccak with AVX2
 Incremental SHAKE-128
 
 Input 0  : 8ee149be89652aa3a96bb1cb21c03a
@@ -181,7 +202,8 @@ Output   : 94f03616a7ed0168833dcec6f51a359b3c3cd42ac0c27409106424f0adb2257f4bfe2
 
 # ---
 
-g++ -std=c++20 -Wall -O3 -I include example/incremental_shake256.cpp && ./a.out
+$ g++ -std=c++20 -Wall -O3 -I include example/incremental_shake256.cpp && ./a.out
+$ g++ -std=c++20 -Wall -O3 -march=native -DUSE_AVX2=1 -I include example/incremental_shake256.cpp && ./a.out # for keccak with AVX2
 Incremental SHAKE-256
 
 Input 0  : 58efcb50a9a8bb61cd25f89be74fe6

--- a/bench/README.md
+++ b/bench/README.md
@@ -23,7 +23,7 @@ make benchmark
 ### On Intel(R) Core(TM) i5-8279U CPU @ 2.40GHz ( using `clang++` )
 
 ```fish
-2022-12-04T12:21:12+04:00
+2022-12-05T17:58:52+04:00
 Running ./bench/a.out
 Run on (8 X 2400 MHz CPU s)
 CPU Caches:
@@ -31,291 +31,291 @@ CPU Caches:
   L1 Instruction 32 KiB
   L2 Unified 256 KiB (x4)
   L3 Unified 6144 KiB
-Load Average: 1.21, 1.91, 1.86
+Load Average: 1.96, 2.35, 2.12
 ------------------------------------------------------------------------------------------------------------
 Benchmark                              Time             CPU   Iterations average_cpu_cycles bytes_per_second
 ------------------------------------------------------------------------------------------------------------
-bench_sha3::keccakf1600              337 ns          337 ns      2078409                790       566.717M/s
-bench_sha3::sha3_224/32              350 ns          350 ns      1984532                821       87.1679M/s
-bench_sha3::sha3_224/64              350 ns          349 ns      2006892                822       174.645M/s
-bench_sha3::sha3_224/128             350 ns          350 ns      1985782                819       349.211M/s
-bench_sha3::sha3_224/256             685 ns          685 ns      1007484             1.625k       356.593M/s
-bench_sha3::sha3_224/512            1360 ns         1358 ns       504432             3.244k       359.445M/s
-bench_sha3::sha3_224/1024           2710 ns         2708 ns       259816             6.486k       360.621M/s
-bench_sha3::sha3_224/2048           5079 ns         5073 ns       136791            12.173k        384.99M/s
-bench_sha3::sha3_224/4096           9758 ns         9754 ns        70876            23.403k       400.486M/s
-bench_sha3::sha3_256/32              351 ns          351 ns      1995393                824       86.9105M/s
-bench_sha3::sha3_256/64              351 ns          350 ns      1978446                822       174.229M/s
-bench_sha3::sha3_256/128             348 ns          347 ns      2006806                816       351.317M/s
-bench_sha3::sha3_256/256             683 ns          683 ns      1011561             1.619k        357.71M/s
-bench_sha3::sha3_256/512            1359 ns         1359 ns       502531             3.243k       359.406M/s
-bench_sha3::sha3_256/1024           2853 ns         2828 ns       257639             6.828k       345.368M/s
-bench_sha3::sha3_256/2048           7075 ns         6474 ns       124365            16.958k       301.689M/s
-bench_sha3::sha3_256/4096          13544 ns        12217 ns        59434             32.48k       319.741M/s
-bench_sha3::sha3_384/32              610 ns          520 ns      1000000             1.441k       58.7114M/s
-bench_sha3::sha3_384/64              390 ns          385 ns      1699902                912       158.718M/s
-bench_sha3::sha3_384/128            1310 ns         1144 ns       953717             3.122k       106.745M/s
-bench_sha3::sha3_384/256            1105 ns         1091 ns       645031              2.63k       223.697M/s
-bench_sha3::sha3_384/512            1963 ns         1826 ns       350233              4.69k       267.442M/s
-bench_sha3::sha3_384/1024           3685 ns         3667 ns       192632             8.823k       266.275M/s
-bench_sha3::sha3_384/2048           7286 ns         7247 ns        95961            17.463k        269.52M/s
-bench_sha3::sha3_384/4096          14435 ns        14325 ns        45709             34.62k        272.69M/s
-bench_sha3::sha3_512/32              399 ns          394 ns      1889497                934       77.5442M/s
-bench_sha3::sha3_512/64              376 ns          374 ns      1786106                880       163.356M/s
-bench_sha3::sha3_512/128             784 ns          776 ns       939787             1.858k       157.314M/s
-bench_sha3::sha3_512/256            1432 ns         1430 ns       446081             3.415k       170.727M/s
-bench_sha3::sha3_512/512            2861 ns         2857 ns       242524             6.844k       170.924M/s
-bench_sha3::sha3_512/1024           5296 ns         5287 ns       127667            12.689k       184.702M/s
-bench_sha3::sha3_512/2048          10303 ns        10288 ns        67643             24.71k       189.846M/s
-bench_sha3::sha3_512/4096          20287 ns        20246 ns        35088            48.669k       192.938M/s
-bench_sha3::shake128/32/32           528 ns          527 ns      1317449              1.25k       115.717M/s
-bench_sha3::shake128/32/64           679 ns          677 ns      1036484             1.612k       135.244M/s
-bench_sha3::shake128/32/128          961 ns          960 ns       721687             2.288k       158.964M/s
-bench_sha3::shake128/64/32           532 ns          532 ns      1319037             1.261k       172.238M/s
-bench_sha3::shake128/64/64           680 ns          678 ns      1014478             1.614k        179.96M/s
-bench_sha3::shake128/64/128          957 ns          955 ns       734469              2.28k       191.673M/s
-bench_sha3::shake128/128/32          535 ns          534 ns      1314727             1.267k       285.559M/s
-bench_sha3::shake128/128/64          678 ns          677 ns      1038345              1.61k       270.567M/s
-bench_sha3::shake128/128/128         962 ns          960 ns       728977             2.292k       254.251M/s
-bench_sha3::shake128/256/32          893 ns          892 ns       796613             2.126k       307.952M/s
-bench_sha3::shake128/256/64         1037 ns         1035 ns       681458             2.472k       294.804M/s
-bench_sha3::shake128/256/128        1321 ns         1319 ns       532583             3.152k       277.748M/s
-bench_sha3::shake128/512/32         1617 ns         1615 ns       432029             3.863k       321.218M/s
-bench_sha3::shake128/512/64         1801 ns         1790 ns       391913             4.305k       306.923M/s
-bench_sha3::shake128/512/128        2077 ns         2065 ns       341038             4.968k       295.579M/s
-bench_sha3::shake128/1024/32        2727 ns         2722 ns       259685             6.527k       369.987M/s
-bench_sha3::shake128/1024/64        2845 ns         2841 ns       246746             6.811k       365.182M/s
-bench_sha3::shake128/1024/128       3167 ns         3156 ns       221853             7.582k        348.11M/s
-bench_sha3::shake128/2048/32        4923 ns         4917 ns       142239            11.798k       403.437M/s
-bench_sha3::shake128/2048/64        5022 ns         5016 ns       139137            12.035k       401.571M/s
-bench_sha3::shake128/2048/128       5334 ns         5322 ns       131797            12.783k       389.914M/s
-bench_sha3::shake128/4096/32        9205 ns         9195 ns        76225            22.075k       428.135M/s
-bench_sha3::shake128/4096/64        9443 ns         9431 ns        74378            22.645k       420.668M/s
-bench_sha3::shake128/4096/128       9889 ns         9879 ns        74104            23.715k       407.778M/s
-bench_sha3::shake256/32/32           532 ns          531 ns      1323902             1.259k       114.949M/s
-bench_sha3::shake256/32/64           658 ns          657 ns      1061362             1.561k       139.402M/s
-bench_sha3::shake256/32/128          927 ns          926 ns       745943             2.207k       164.864M/s
-bench_sha3::shake256/64/32           530 ns          529 ns      1359910             1.255k       173.069M/s
-bench_sha3::shake256/64/64           661 ns          660 ns      1052885              1.57k        185.02M/s
-bench_sha3::shake256/64/128          923 ns          920 ns       768184             2.198k       198.976M/s
-bench_sha3::shake256/128/32          525 ns          524 ns      1324754             1.242k       291.207M/s
-bench_sha3::shake256/128/64          662 ns          660 ns      1074048             1.571k       277.423M/s
-bench_sha3::shake256/128/128         915 ns          914 ns       771613             2.179k       267.171M/s
-bench_sha3::shake256/256/32          916 ns          912 ns       782709             2.179k       301.158M/s
-bench_sha3::shake256/256/64         1029 ns         1027 ns       609278             2.452k       297.235M/s
-bench_sha3::shake256/256/128        1324 ns         1313 ns       538386             3.158k        278.88M/s
-bench_sha3::shake256/512/32         1743 ns         1711 ns       412378             4.163k       303.294M/s
-bench_sha3::shake256/512/64         1841 ns         1814 ns       309400               4.4k       302.778M/s
-bench_sha3::shake256/512/128        2040 ns         2022 ns       349883             4.878k       301.866M/s
-bench_sha3::shake256/1024/32        3076 ns         3041 ns       229573             7.366k       331.181M/s
-bench_sha3::shake256/1024/64        3163 ns         3148 ns       221016             7.574k       329.635M/s
-bench_sha3::shake256/1024/128       3374 ns         3366 ns       205599              8.08k       326.379M/s
-bench_sha3::shake256/2048/32        5832 ns         5824 ns       121143            13.979k       340.625M/s
-bench_sha3::shake256/2048/64        5846 ns         5840 ns       119806            14.013k       344.886M/s
-bench_sha3::shake256/2048/128       6077 ns         6073 ns       113710            14.569k       341.734M/s
-bench_sha3::shake256/4096/32       10894 ns        10883 ns        63854            26.128k       361.735M/s
-bench_sha3::shake256/4096/64       11004 ns        10993 ns        63002            26.393k       360.876M/s
-bench_sha3::shake256/4096/128      11268 ns        11257 ns        62091            27.025k       357.843M/s
+bench_sha3::keccakf1600              340 ns          340 ns      2065256                798       561.678M/s
+bench_sha3::sha3_224/32              358 ns          358 ns      1961389                840       85.2962M/s
+bench_sha3::sha3_224/64              353 ns          352 ns      1959034                829       173.213M/s
+bench_sha3::sha3_224/128             358 ns          358 ns      1952814                839       341.234M/s
+bench_sha3::sha3_224/256             702 ns          701 ns       992753             1.666k       348.264M/s
+bench_sha3::sha3_224/512            1382 ns         1381 ns       507474             3.298k        353.63M/s
+bench_sha3::sha3_224/1024           2737 ns         2734 ns       251394             6.549k       357.232M/s
+bench_sha3::sha3_224/2048           5090 ns         5085 ns       130748            12.197k       384.068M/s
+bench_sha3::sha3_224/4096           9869 ns         9855 ns        68754            23.669k       396.366M/s
+bench_sha3::sha3_256/32              354 ns          354 ns      1968764                831       86.2062M/s
+bench_sha3::sha3_256/64              355 ns          355 ns      1963072                832       171.983M/s
+bench_sha3::sha3_256/128             351 ns          351 ns      1999880                825       347.855M/s
+bench_sha3::sha3_256/256             693 ns          692 ns      1002305             1.644k       352.655M/s
+bench_sha3::sha3_256/512            1374 ns         1367 ns       494637             3.278k       357.173M/s
+bench_sha3::sha3_256/1024           2747 ns         2729 ns       254274             6.575k       357.795M/s
+bench_sha3::sha3_256/2048           5434 ns         5429 ns       127220            13.022k       359.749M/s
+bench_sha3::sha3_256/4096          10471 ns        10465 ns        66371            25.111k       373.258M/s
+bench_sha3::sha3_384/32              357 ns          356 ns      1962230                834        85.664M/s
+bench_sha3::sha3_384/64              357 ns          357 ns      1969468                835       171.179M/s
+bench_sha3::sha3_384/128             704 ns          703 ns       997236             1.668k       173.678M/s
+bench_sha3::sha3_384/256            1037 ns         1036 ns       665007             2.467k       235.733M/s
+bench_sha3::sha3_384/512            1713 ns         1711 ns       410374             4.091k       285.327M/s
+bench_sha3::sha3_384/1024           3430 ns         3426 ns       205157             8.212k       285.004M/s
+bench_sha3::sha3_384/2048           6782 ns         6775 ns        99873            16.255k       288.273M/s
+bench_sha3::sha3_384/4096          13588 ns        13577 ns        50472             32.59k       287.718M/s
+bench_sha3::sha3_512/32              358 ns          357 ns      1936569                836       85.4371M/s
+bench_sha3::sha3_512/64              362 ns          360 ns      1978743                847       169.354M/s
+bench_sha3::sha3_512/128             755 ns          741 ns       959443             1.789k        164.82M/s
+bench_sha3::sha3_512/256            1372 ns         1371 ns       501824             3.271k       178.123M/s
+bench_sha3::sha3_512/512            2871 ns         2863 ns       215611             6.869k       170.556M/s
+bench_sha3::sha3_512/1024           5333 ns         5323 ns       129694             12.78k       183.469M/s
+bench_sha3::sha3_512/2048          10068 ns        10057 ns        64825            24.144k       194.209M/s
+bench_sha3::sha3_512/4096          19382 ns        19369 ns        34589            46.496k       201.675M/s
+bench_sha3::shake128/32/32           517 ns          516 ns      1356274             1.223k       118.369M/s
+bench_sha3::shake128/32/64           695 ns          693 ns       976549             1.651k       132.162M/s
+bench_sha3::shake128/32/128          923 ns          921 ns       749722             2.198k       165.618M/s
+bench_sha3::shake128/64/32           509 ns          508 ns      1362769             1.206k       180.062M/s
+bench_sha3::shake128/64/64           643 ns          642 ns      1053281             1.526k       190.137M/s
+bench_sha3::shake128/64/128          918 ns          917 ns       762071             2.186k       199.769M/s
+bench_sha3::shake128/128/32          513 ns          512 ns      1384357             1.214k       298.264M/s
+bench_sha3::shake128/128/64          659 ns          658 ns      1075566             1.565k       278.272M/s
+bench_sha3::shake128/128/128         916 ns          915 ns       743692             2.182k        266.79M/s
+bench_sha3::shake128/256/32          844 ns          844 ns       813897             2.011k       325.564M/s
+bench_sha3::shake128/256/64          985 ns          984 ns       702896             2.347k       310.169M/s
+bench_sha3::shake128/256/128        1249 ns         1248 ns       559396             2.982k       293.374M/s
+bench_sha3::shake128/512/32         1524 ns         1523 ns       458445             3.642k       340.699M/s
+bench_sha3::shake128/512/64         1690 ns         1684 ns       418908              4.04k       326.175M/s
+bench_sha3::shake128/512/128        1943 ns         1941 ns       359170             4.647k       314.518M/s
+bench_sha3::shake128/1024/32        2569 ns         2567 ns       272913              6.15k       392.354M/s
+bench_sha3::shake128/1024/64        2698 ns         2694 ns       261999             6.459k       385.131M/s
+bench_sha3::shake128/1024/128       2956 ns         2953 ns       237119             7.079k       371.985M/s
+bench_sha3::shake128/2048/32        4628 ns         4622 ns       151232            11.089k       429.216M/s
+bench_sha3::shake128/2048/64        4782 ns         4776 ns       146864             11.46k        421.76M/s
+bench_sha3::shake128/2048/128       5097 ns         5088 ns       132754            12.216k       407.834M/s
+bench_sha3::shake128/4096/32        8680 ns         8670 ns        80138            20.814k       454.076M/s
+bench_sha3::shake128/4096/64        8837 ns         8827 ns        75576            21.191k       449.461M/s
+bench_sha3::shake128/4096/128       9321 ns         9274 ns        73512            22.355k       434.373M/s
+bench_sha3::shake256/32/32           504 ns          503 ns      1000000             1.192k       121.389M/s
+bench_sha3::shake256/32/64           623 ns          622 ns      1117800             1.479k       147.188M/s
+bench_sha3::shake256/32/128          868 ns          867 ns       791658             2.067k       176.013M/s
+bench_sha3::shake256/64/32           503 ns          502 ns      1382525             1.189k       182.473M/s
+bench_sha3::shake256/64/64           638 ns          637 ns      1086332             1.515k       191.777M/s
+bench_sha3::shake256/64/128          858 ns          858 ns       815765             2.043k       213.502M/s
+bench_sha3::shake256/128/32          495 ns          495 ns      1384220             1.173k       308.487M/s
+bench_sha3::shake256/128/64          615 ns          615 ns      1122298              1.46k       297.827M/s
+bench_sha3::shake256/128/128         857 ns          857 ns       811491             2.041k       285.042M/s
+bench_sha3::shake256/256/32          849 ns          848 ns       818369             2.021k       323.842M/s
+bench_sha3::shake256/256/64          968 ns          967 ns       724570             2.308k       315.438M/s
+bench_sha3::shake256/256/128        1228 ns         1226 ns       568676             2.931k       298.638M/s
+bench_sha3::shake256/512/32         1597 ns         1594 ns       431678             3.817k       325.549M/s
+bench_sha3::shake256/512/64         1691 ns         1685 ns       407538             4.041k       325.954M/s
+bench_sha3::shake256/512/128        1886 ns         1884 ns       358042             4.511k       323.978M/s
+bench_sha3::shake256/1024/32        2913 ns         2909 ns       243776             6.975k       346.178M/s
+bench_sha3::shake256/1024/64        3007 ns         3004 ns       230835             7.201k       345.353M/s
+bench_sha3::shake256/1024/128       3241 ns         3238 ns       215513             7.761k       339.338M/s
+bench_sha3::shake256/2048/32        5610 ns         5603 ns       121701            13.448k       354.006M/s
+bench_sha3::shake256/2048/64        5690 ns         5684 ns       121621             13.64k       354.339M/s
+bench_sha3::shake256/2048/128       5978 ns         5974 ns       115401             14.33k       347.396M/s
+bench_sha3::shake256/4096/32       31062 ns        11662 ns        64059            74.532k        337.58M/s
+bench_sha3::shake256/4096/64       11471 ns        11416 ns        62774            27.513k       347.511M/s
+bench_sha3::shake256/4096/128      12172 ns        11755 ns        53348            29.197k       342.677M/s
 ```
 
 ### On AWS Graviton2 ( using `g++` )
 
 ```fish
-2022-12-04T08:25:39+00:00
+2022-12-05T14:02:59+00:00
 Running ./bench/a.out
 Run on (16 X 166.66 MHz CPU s)
 CPU Caches:
   L1 Data 32 KiB (x16)
   L1 Instruction 48 KiB (x16)
   L2 Unified 2048 KiB (x4)
-Load Average: 0.15, 0.03, 0.01
+Load Average: 0.08, 0.02, 0.01
 -----------------------------------------------------------------------------------------
 Benchmark                              Time             CPU   Iterations bytes_per_second
 -----------------------------------------------------------------------------------------
-bench_sha3::keccakf1600             1500 ns         1500 ns       466444       127.135M/s
-bench_sha3::sha3_224/32             1635 ns         1635 ns       428101       18.6681M/s
-bench_sha3::sha3_224/64             1628 ns         1628 ns       430004       37.4943M/s
-bench_sha3::sha3_224/128            1626 ns         1626 ns       430405       75.0555M/s
-bench_sha3::sha3_224/256            3216 ns         3216 ns       217680       75.9224M/s
-bench_sha3::sha3_224/512            6407 ns         6407 ns       109224       76.2132M/s
-bench_sha3::sha3_224/1024          12766 ns        12766 ns        54832       76.4976M/s
-bench_sha3::sha3_224/2048          23889 ns        23888 ns        29302       81.7601M/s
-bench_sha3::sha3_224/4096          46132 ns        46131 ns        15175       84.6774M/s
-bench_sha3::sha3_256/32             1805 ns         1805 ns       387825       16.9084M/s
-bench_sha3::sha3_256/64             1800 ns         1800 ns       388855       33.9065M/s
-bench_sha3::sha3_256/128            1796 ns         1796 ns       389810       67.9789M/s
-bench_sha3::sha3_256/256            3553 ns         3553 ns       197000       68.7079M/s
-bench_sha3::sha3_256/512            7078 ns         7078 ns        98871       68.9847M/s
-bench_sha3::sha3_256/1024          14101 ns        14101 ns        49642       69.2559M/s
-bench_sha3::sha3_256/2048          28160 ns        28159 ns        24859       69.3596M/s
-bench_sha3::sha3_256/4096          54503 ns        54502 ns        12843       71.6714M/s
-bench_sha3::sha3_384/32             1591 ns         1591 ns       440055        19.185M/s
-bench_sha3::sha3_384/64             1589 ns         1589 ns       440530       38.4125M/s
-bench_sha3::sha3_384/128            3131 ns         3131 ns       223592       38.9912M/s
-bench_sha3::sha3_384/256            4681 ns         4681 ns       149779       52.1593M/s
-bench_sha3::sha3_384/512            7768 ns         7768 ns        90109       62.8584M/s
-bench_sha3::sha3_384/1024          15468 ns        15468 ns        45255       63.1363M/s
-bench_sha3::sha3_384/2048          30881 ns        30881 ns        22667       63.2475M/s
-bench_sha3::sha3_384/4096          61715 ns        61714 ns        11341       63.2957M/s
-bench_sha3::sha3_512/32             1653 ns         1653 ns       423477       18.4631M/s
-bench_sha3::sha3_512/64             1647 ns         1647 ns       425080       37.0654M/s
-bench_sha3::sha3_512/128            3254 ns         3254 ns       215150       37.5197M/s
-bench_sha3::sha3_512/256            6473 ns         6473 ns       108121       37.7176M/s
-bench_sha3::sha3_512/512           12892 ns        12891 ns        54296       37.8763M/s
-bench_sha3::sha3_512/1024          24128 ns        24127 ns        29013       40.4762M/s
-bench_sha3::sha3_512/2048          46602 ns        46601 ns        15021       41.9117M/s
-bench_sha3::sha3_512/4096          91539 ns        91537 ns         7647        42.674M/s
-bench_sha3::shake128/32/32          1732 ns         1732 ns       404234       35.2481M/s
-bench_sha3::shake128/32/64          1787 ns         1787 ns       391652       51.2245M/s
-bench_sha3::shake128/32/128         1899 ns         1899 ns       368665       80.3652M/s
-bench_sha3::shake128/64/32          1734 ns         1734 ns       403732       52.8043M/s
-bench_sha3::shake128/64/64          1789 ns         1789 ns       391178       68.2173M/s
-bench_sha3::shake128/64/128         1901 ns         1901 ns       368249       96.3289M/s
-bench_sha3::shake128/128/32         1728 ns         1728 ns       405057       88.2951M/s
-bench_sha3::shake128/128/64         1784 ns         1784 ns       392404       102.647M/s
-bench_sha3::shake128/128/128        1895 ns         1895 ns       369362       128.821M/s
-bench_sha3::shake128/256/32         3342 ns         3342 ns       209471       82.1924M/s
-bench_sha3::shake128/256/64         3398 ns         3397 ns       206038       89.8238M/s
-bench_sha3::shake128/256/128        3509 ns         3509 ns       199497       104.371M/s
-bench_sha3::shake128/512/32         6598 ns         6597 ns       106063       78.6369M/s
-bench_sha3::shake128/512/64         6652 ns         6652 ns       105239       82.5816M/s
-bench_sha3::shake128/512/128        6765 ns         6765 ns       103472       90.2215M/s
-bench_sha3::shake128/1024/32       11441 ns        11441 ns        61175       88.0276M/s
-bench_sha3::shake128/1024/64       11496 ns        11496 ns        60891       90.2572M/s
-bench_sha3::shake128/1024/128      11610 ns        11609 ns        60297       94.6325M/s
-bench_sha3::shake128/2048/32       21118 ns        21118 ns        33146        93.932M/s
-bench_sha3::shake128/2048/64       21176 ns        21175 ns        33058       95.1201M/s
-bench_sha3::shake128/2048/128      21286 ns        21285 ns        32884       97.4935M/s
-bench_sha3::shake128/4096/32       40496 ns        40495 ns        17286       97.2153M/s
-bench_sha3::shake128/4096/64       40551 ns        40551 ns        17262       97.8341M/s
-bench_sha3::shake128/4096/128      40664 ns        40662 ns        17214       99.0674M/s
-bench_sha3::shake256/32/32          1629 ns         1629 ns       429762       37.4735M/s
-bench_sha3::shake256/32/64          1685 ns         1685 ns       415546       54.3499M/s
-bench_sha3::shake256/32/128         1796 ns         1796 ns       389788        84.969M/s
-bench_sha3::shake256/64/32          1624 ns         1624 ns       431013       56.3726M/s
-bench_sha3::shake256/64/64          1680 ns         1680 ns       416737       72.6771M/s
-bench_sha3::shake256/64/128         1791 ns         1791 ns       390834       102.235M/s
-bench_sha3::shake256/128/32         1620 ns         1620 ns       432202       94.2104M/s
-bench_sha3::shake256/128/64         1675 ns         1675 ns       417816       109.297M/s
-bench_sha3::shake256/128/128        1787 ns         1787 ns       391714       136.634M/s
-bench_sha3::shake256/256/32         3130 ns         3130 ns       223615       87.7431M/s
-bench_sha3::shake256/256/64         3186 ns         3186 ns       219701       95.7824M/s
-bench_sha3::shake256/256/128        3297 ns         3297 ns       212278       111.059M/s
-bench_sha3::shake256/512/32         6165 ns         6164 ns       113503       84.1613M/s
-bench_sha3::shake256/512/64         6222 ns         6222 ns       112500       88.2927M/s
-bench_sha3::shake256/512/128        6334 ns         6334 ns       110480       96.3609M/s
-bench_sha3::shake256/1024/32       12216 ns        12216 ns        57299       82.4405M/s
-bench_sha3::shake256/1024/64       12272 ns        12271 ns        57040       84.5536M/s
-bench_sha3::shake256/1024/128      12384 ns        12383 ns        56518       88.7196M/s
-bench_sha3::shake256/2048/32       24317 ns        24317 ns        28786       81.5744M/s
-bench_sha3::shake256/2048/64       24373 ns        24373 ns        28721       82.6398M/s
-bench_sha3::shake256/2048/128      24484 ns        24484 ns        28590        84.757M/s
-bench_sha3::shake256/4096/32       46995 ns        46994 ns        14895       83.7723M/s
-bench_sha3::shake256/4096/64       47050 ns        47049 ns        14878       84.3218M/s
-bench_sha3::shake256/4096/128      47160 ns        47160 ns        14842       85.4183M/s
+bench_sha3::keccakf1600              701 ns          701 ns       998129       272.237M/s
+bench_sha3::sha3_224/32              774 ns          774 ns       905789       39.4228M/s
+bench_sha3::sha3_224/64              767 ns          767 ns       912238       79.5407M/s
+bench_sha3::sha3_224/128             765 ns          765 ns       915549        159.67M/s
+bench_sha3::sha3_224/256            1485 ns         1485 ns       471258       164.379M/s
+bench_sha3::sha3_224/512            2944 ns         2944 ns       237831       165.851M/s
+bench_sha3::sha3_224/1024           5838 ns         5837 ns       119914       167.294M/s
+bench_sha3::sha3_224/2048          10891 ns        10891 ns        64273       179.337M/s
+bench_sha3::sha3_224/4096          20995 ns        20994 ns        33344       186.063M/s
+bench_sha3::sha3_256/32              786 ns          785 ns       891143       38.8531M/s
+bench_sha3::sha3_256/64              780 ns          780 ns       897117       78.2354M/s
+bench_sha3::sha3_256/128             784 ns          784 ns       901807       155.715M/s
+bench_sha3::sha3_256/256            1500 ns         1499 ns       466889       162.817M/s
+bench_sha3::sha3_256/512            2964 ns         2964 ns       236298       164.763M/s
+bench_sha3::sha3_256/1024           5867 ns         5867 ns       119318       166.443M/s
+bench_sha3::sha3_256/2048          11684 ns        11683 ns        59917       167.172M/s
+bench_sha3::sha3_256/4096          22572 ns        22571 ns        31014       173.063M/s
+bench_sha3::sha3_384/32              768 ns          768 ns       911442       39.7362M/s
+bench_sha3::sha3_384/64              765 ns          765 ns       915024       79.7896M/s
+bench_sha3::sha3_384/128            1488 ns         1488 ns       470361       82.0236M/s
+bench_sha3::sha3_384/256            2212 ns         2212 ns       316508       110.392M/s
+bench_sha3::sha3_384/512            3662 ns         3661 ns       191664       133.358M/s
+bench_sha3::sha3_384/1024           7248 ns         7248 ns        96637       134.734M/s
+bench_sha3::sha3_384/2048          14441 ns        14441 ns        48470       135.249M/s
+bench_sha3::sha3_384/4096          28832 ns        28831 ns        24279       135.489M/s
+bench_sha3::sha3_512/32              750 ns          750 ns       933092       40.6803M/s
+bench_sha3::sha3_512/64              754 ns          754 ns       928282       80.9409M/s
+bench_sha3::sha3_512/128            1454 ns         1454 ns       481469       83.9694M/s
+bench_sha3::sha3_512/256            2869 ns         2869 ns       243961       85.0878M/s
+bench_sha3::sha3_512/512            5689 ns         5689 ns       123026        85.826M/s
+bench_sha3::sha3_512/1024          10618 ns        10617 ns        65926       91.9767M/s
+bench_sha3::sha3_512/2048          20475 ns        20474 ns        34190       95.3961M/s
+bench_sha3::sha3_512/4096          40183 ns        40181 ns        17420       97.2157M/s
+bench_sha3::shake128/32/32           828 ns          828 ns       845234       73.7036M/s
+bench_sha3::shake128/32/64           877 ns          877 ns       798334       104.419M/s
+bench_sha3::shake128/32/128          975 ns          975 ns       718130       156.551M/s
+bench_sha3::shake128/64/32           830 ns          830 ns       843543       110.327M/s
+bench_sha3::shake128/64/64           879 ns          879 ns       796684       138.944M/s
+bench_sha3::shake128/64/128          976 ns          976 ns       717167       187.602M/s
+bench_sha3::shake128/128/32          825 ns          825 ns       848384       184.941M/s
+bench_sha3::shake128/128/64          874 ns          874 ns       800900       209.542M/s
+bench_sha3::shake128/128/128         971 ns          971 ns       720681       251.356M/s
+bench_sha3::shake128/256/32         1548 ns         1548 ns       452232       177.453M/s
+bench_sha3::shake128/256/64         1597 ns         1597 ns       438421        191.13M/s
+bench_sha3::shake128/256/128        1694 ns         1694 ns       413196       216.158M/s
+bench_sha3::shake128/512/32         3015 ns         3015 ns       232238       172.071M/s
+bench_sha3::shake128/512/64         3067 ns         3067 ns       228456       179.129M/s
+bench_sha3::shake128/512/128        3163 ns         3162 ns       221299       193.001M/s
+bench_sha3::shake128/1024/32        5183 ns         5182 ns       135065       194.326M/s
+bench_sha3::shake128/1024/64        5231 ns         5231 ns       133810       198.357M/s
+bench_sha3::shake128/1024/128       5330 ns         5330 ns       131323       206.114M/s
+bench_sha3::shake128/2048/32        9508 ns         9508 ns        73620       208.638M/s
+bench_sha3::shake128/2048/64        9557 ns         9557 ns        73248       210.757M/s
+bench_sha3::shake128/2048/128       9655 ns         9654 ns        72508       214.952M/s
+bench_sha3::shake128/4096/32       18173 ns        18173 ns        38517       216.626M/s
+bench_sha3::shake128/4096/64       18224 ns        18224 ns        38412       217.699M/s
+bench_sha3::shake128/4096/128      18321 ns        18321 ns        38205       219.875M/s
+bench_sha3::shake256/32/32           825 ns          825 ns       848464       73.9826M/s
+bench_sha3::shake256/32/64           881 ns          881 ns       794815       103.956M/s
+bench_sha3::shake256/32/128          992 ns          992 ns       705551       153.796M/s
+bench_sha3::shake256/64/32           822 ns          821 ns       852082       111.447M/s
+bench_sha3::shake256/64/64           877 ns          877 ns       797877       139.163M/s
+bench_sha3::shake256/64/128          989 ns          989 ns       708029       185.219M/s
+bench_sha3::shake256/128/32          816 ns          816 ns       857694       186.954M/s
+bench_sha3::shake256/128/64          872 ns          872 ns       803111       210.084M/s
+bench_sha3::shake256/128/128         983 ns          983 ns       712161       248.384M/s
+bench_sha3::shake256/256/32         1530 ns         1530 ns       457383       179.476M/s
+bench_sha3::shake256/256/64         1586 ns         1586 ns       441349       192.412M/s
+bench_sha3::shake256/256/128        1697 ns         1697 ns       412386       215.744M/s
+bench_sha3::shake256/512/32         2973 ns         2973 ns       235511        174.52M/s
+bench_sha3::shake256/512/64         3029 ns         3029 ns       231123       181.339M/s
+bench_sha3::shake256/512/128        3140 ns         3140 ns       222963       194.375M/s
+bench_sha3::shake256/1024/32        5834 ns         5834 ns       119974        172.62M/s
+bench_sha3::shake256/1024/64        5890 ns         5890 ns       118847       176.166M/s
+bench_sha3::shake256/1024/128       6002 ns         6001 ns       116629       183.062M/s
+bench_sha3::shake256/2048/32       11555 ns        11555 ns        60580       171.676M/s
+bench_sha3::shake256/2048/64       11611 ns        11611 ns        60288       173.475M/s
+bench_sha3::shake256/2048/128      11722 ns        11722 ns        59714       177.041M/s
+bench_sha3::shake256/4096/32       22273 ns        22272 ns        31428       176.757M/s
+bench_sha3::shake256/4096/64       22328 ns        22327 ns        31351       177.689M/s
+bench_sha3::shake256/4096/128      22440 ns        22439 ns        31196       179.524M/s
 ```
 
 ### On AWS Graviton2 ( using `clang++` )
 
 ```fish
-2022-12-04T08:29:25+00:00
+2022-12-05T14:04:48+00:00
 Running ./bench/a.out
 Run on (16 X 166.66 MHz CPU s)
 CPU Caches:
   L1 Data 32 KiB (x16)
   L1 Instruction 48 KiB (x16)
   L2 Unified 2048 KiB (x4)
-Load Average: 0.14, 0.16, 0.08
+Load Average: 0.45, 0.21, 0.08
 -----------------------------------------------------------------------------------------
 Benchmark                              Time             CPU   Iterations bytes_per_second
 -----------------------------------------------------------------------------------------
-bench_sha3::keccakf1600             1399 ns         1399 ns       500352       136.378M/s
-bench_sha3::sha3_224/32             1467 ns         1467 ns       476901       20.7973M/s
-bench_sha3::sha3_224/64             1463 ns         1463 ns       478473       41.7203M/s
-bench_sha3::sha3_224/128            1455 ns         1455 ns       481031       83.8845M/s
-bench_sha3::sha3_224/256            2875 ns         2875 ns       243562       84.9254M/s
-bench_sha3::sha3_224/512            5729 ns         5729 ns       122145       85.2279M/s
-bench_sha3::sha3_224/1024          11413 ns        11412 ns        61340       85.5705M/s
-bench_sha3::sha3_224/2048          21349 ns        21348 ns        32793        91.488M/s
-bench_sha3::sha3_224/4096          41216 ns        41216 ns        16984       94.7758M/s
-bench_sha3::sha3_256/32             1466 ns         1466 ns       477362       20.8112M/s
-bench_sha3::sha3_256/64             1461 ns         1461 ns       479153       41.7786M/s
-bench_sha3::sha3_256/128            1453 ns         1453 ns       481630        83.991M/s
-bench_sha3::sha3_256/256            2871 ns         2871 ns       243809       85.0324M/s
-bench_sha3::sha3_256/512            5720 ns         5720 ns       122249       85.3693M/s
-bench_sha3::sha3_256/1024          11400 ns        11400 ns        61404       85.6666M/s
-bench_sha3::sha3_256/2048          22757 ns        22757 ns        30760       85.8263M/s
-bench_sha3::sha3_256/4096          44037 ns        44037 ns        15893       88.7033M/s
-bench_sha3::sha3_384/32             1454 ns         1454 ns       481433       20.9893M/s
-bench_sha3::sha3_384/64             1450 ns         1450 ns       482857       42.1036M/s
-bench_sha3::sha3_384/128            2871 ns         2871 ns       243832       42.5207M/s
-bench_sha3::sha3_384/256            4281 ns         4281 ns       163524        57.034M/s
-bench_sha3::sha3_384/512            7120 ns         7120 ns        98312       68.5776M/s
-bench_sha3::sha3_384/1024          14191 ns        14191 ns        49326       68.8145M/s
-bench_sha3::sha3_384/2048          28341 ns        28340 ns        24700       68.9176M/s
-bench_sha3::sha3_384/4096          56642 ns        56641 ns        12358       68.9649M/s
-bench_sha3::sha3_512/32             1445 ns         1445 ns       484534       21.1241M/s
-bench_sha3::sha3_512/64             1440 ns         1440 ns       486259       42.3996M/s
-bench_sha3::sha3_512/128            2853 ns         2853 ns       245325       42.7822M/s
-bench_sha3::sha3_512/256            5689 ns         5689 ns       122993       42.9125M/s
-bench_sha3::sha3_512/512           11336 ns        11336 ns        61747       43.0732M/s
-bench_sha3::sha3_512/1024          21217 ns        21216 ns        32995       46.0291M/s
-bench_sha3::sha3_512/2048          40972 ns        40972 ns        17084       47.6698M/s
-bench_sha3::sha3_512/4096          80487 ns        80486 ns         8697       48.5331M/s
-bench_sha3::shake128/32/32          1850 ns         1850 ns       378416       32.9956M/s
-bench_sha3::shake128/32/64          2212 ns         2212 ns       316465       41.3904M/s
-bench_sha3::shake128/32/128         2936 ns         2936 ns       238428       51.9732M/s
-bench_sha3::shake128/64/32          1852 ns         1852 ns       378117       49.4368M/s
-bench_sha3::shake128/64/64          2214 ns         2214 ns       316325       55.1377M/s
-bench_sha3::shake128/64/128         2938 ns         2938 ns       238261        62.324M/s
-bench_sha3::shake128/128/32         1846 ns         1846 ns       379108       82.6389M/s
-bench_sha3::shake128/128/64         2208 ns         2208 ns       316967       82.9158M/s
-bench_sha3::shake128/128/128        2933 ns         2933 ns       238703       83.2525M/s
-bench_sha3::shake128/256/32         3268 ns         3268 ns       214229       84.0575M/s
-bench_sha3::shake128/256/64         3630 ns         3630 ns       192891       84.0811M/s
-bench_sha3::shake128/256/128        4354 ns         4354 ns       160788       84.1146M/s
-bench_sha3::shake128/512/32         6136 ns         6136 ns       114136       84.5556M/s
-bench_sha3::shake128/512/64         6497 ns         6497 ns       107717       84.5502M/s
-bench_sha3::shake128/512/128        7221 ns         7221 ns        96938       84.5275M/s
-bench_sha3::shake128/1024/32       10400 ns        10400 ns        67304       96.8346M/s
-bench_sha3::shake128/1024/64       10762 ns        10762 ns        65052       96.4102M/s
-bench_sha3::shake128/1024/128      11487 ns        11487 ns        60960        95.645M/s
-bench_sha3::shake128/2048/32       18927 ns        18927 ns        36985       104.807M/s
-bench_sha3::shake128/2048/64       19288 ns        19288 ns        36291       104.425M/s
-bench_sha3::shake128/2048/128      20014 ns        20014 ns        34976       103.689M/s
-bench_sha3::shake128/4096/32       35993 ns        35993 ns        19448       109.377M/s
-bench_sha3::shake128/4096/64       36354 ns        36354 ns        19255        109.13M/s
-bench_sha3::shake128/4096/128      37079 ns        37078 ns        18880       108.643M/s
-bench_sha3::shake256/32/32          1846 ns         1846 ns       379422       33.0721M/s
-bench_sha3::shake256/32/64          2208 ns         2208 ns       317243       41.4731M/s
-bench_sha3::shake256/32/128         2932 ns         2932 ns       238780       52.0511M/s
-bench_sha3::shake256/64/32          1839 ns         1839 ns       380566       49.7753M/s
-bench_sha3::shake256/64/64          2202 ns         2202 ns       317950       55.4479M/s
-bench_sha3::shake256/64/128         2926 ns         2926 ns       239268       62.5877M/s
-bench_sha3::shake256/128/32         1829 ns         1829 ns       382760       83.4085M/s
-bench_sha3::shake256/128/64         2192 ns         2192 ns       319558       83.5512M/s
-bench_sha3::shake256/128/128        2916 ns         2916 ns       240085       83.7388M/s
-bench_sha3::shake256/256/32         3252 ns         3251 ns       215593       84.4725M/s
-bench_sha3::shake256/256/64         3622 ns         3622 ns       193242       84.2555M/s
-bench_sha3::shake256/256/128        4333 ns         4333 ns       161443       84.5103M/s
-bench_sha3::shake256/512/32         6096 ns         6096 ns       114871       85.1034M/s
-bench_sha3::shake256/512/64         6457 ns         6457 ns       108388       85.0709M/s
-bench_sha3::shake256/512/128        7183 ns         7183 ns        97472       84.9694M/s
-bench_sha3::shake256/1024/32       11776 ns        11776 ns        59442       85.5199M/s
-bench_sha3::shake256/1024/64       12137 ns        12137 ns        57673       85.4906M/s
-bench_sha3::shake256/1024/128      12861 ns        12860 ns        54426       85.4272M/s
-bench_sha3::shake256/2048/32       23134 ns        23134 ns        30258       85.7459M/s
-bench_sha3::shake256/2048/64       23495 ns        23494 ns        29795       85.7297M/s
-bench_sha3::shake256/2048/128      24221 ns        24221 ns        28900       85.6789M/s
-bench_sha3::shake256/4096/32       44419 ns        44418 ns        15759       88.6293M/s
-bench_sha3::shake256/4096/64       44785 ns        44782 ns        15632       88.5902M/s
-bench_sha3::shake256/4096/128      45503 ns        45503 ns        15384       88.5295M/s
+bench_sha3::keccakf1600              752 ns          752 ns       930434       253.675M/s
+bench_sha3::sha3_224/32              822 ns          822 ns       851127       37.1269M/s
+bench_sha3::sha3_224/64              817 ns          817 ns       856931       74.7184M/s
+bench_sha3::sha3_224/128             810 ns          810 ns       864367       150.741M/s
+bench_sha3::sha3_224/256            1593 ns         1593 ns       439877        153.26M/s
+bench_sha3::sha3_224/512            3155 ns         3155 ns       221702       154.787M/s
+bench_sha3::sha3_224/1024           6257 ns         6257 ns       111863       156.068M/s
+bench_sha3::sha3_224/2048          11674 ns        11673 ns        59942       167.316M/s
+bench_sha3::sha3_224/4096          22495 ns        22495 ns        31118       173.649M/s
+bench_sha3::sha3_256/32              821 ns          821 ns       852544       37.1673M/s
+bench_sha3::sha3_256/64              815 ns          815 ns       858390       74.8484M/s
+bench_sha3::sha3_256/128             808 ns          808 ns       866249       151.078M/s
+bench_sha3::sha3_256/256            1599 ns         1599 ns       438184       152.652M/s
+bench_sha3::sha3_256/512            3151 ns         3151 ns       222228       154.954M/s
+bench_sha3::sha3_256/1024           6248 ns         6248 ns       112027         156.3M/s
+bench_sha3::sha3_256/2048          12453 ns        12453 ns        56211        156.84M/s
+bench_sha3::sha3_256/4096          24073 ns        24072 ns        29079       162.273M/s
+bench_sha3::sha3_384/32              808 ns          808 ns       866155       37.7625M/s
+bench_sha3::sha3_384/64              804 ns          804 ns       870884       75.9388M/s
+bench_sha3::sha3_384/128            1581 ns         1581 ns       442780       77.2158M/s
+bench_sha3::sha3_384/256            2354 ns         2354 ns       298225       103.708M/s
+bench_sha3::sha3_384/512            3897 ns         3897 ns       179614       125.294M/s
+bench_sha3::sha3_384/1024           7753 ns         7753 ns        90230       125.964M/s
+bench_sha3::sha3_384/2048          15473 ns        15473 ns        45246       126.231M/s
+bench_sha3::sha3_384/4096          30897 ns        30897 ns        22658        126.43M/s
+bench_sha3::sha3_512/32              799 ns          798 ns       876634       38.2188M/s
+bench_sha3::sha3_512/64              793 ns          793 ns       882382       76.9419M/s
+bench_sha3::sha3_512/128            1564 ns         1564 ns       447609       78.0572M/s
+bench_sha3::sha3_512/256            3108 ns         3108 ns       225178       78.5413M/s
+bench_sha3::sha3_512/512            6175 ns         6175 ns       113363       79.0768M/s
+bench_sha3::sha3_512/1024          11540 ns        11540 ns        60666       84.6254M/s
+bench_sha3::sha3_512/2048          22268 ns        22267 ns        31436       87.7127M/s
+bench_sha3::sha3_512/4096          43722 ns        43721 ns        16010       89.3441M/s
+bench_sha3::shake128/32/32          1204 ns         1204 ns       582024       50.7095M/s
+bench_sha3::shake128/32/64          1566 ns         1566 ns       447089       58.4761M/s
+bench_sha3::shake128/32/128         2290 ns         2290 ns       305675       66.6406M/s
+bench_sha3::shake128/64/32          1207 ns         1207 ns       580068       75.8694M/s
+bench_sha3::shake128/64/64          1569 ns         1569 ns       446243       77.8187M/s
+bench_sha3::shake128/64/128         2293 ns         2293 ns       305323       79.8652M/s
+bench_sha3::shake128/128/32         1204 ns         1204 ns       581400       126.739M/s
+bench_sha3::shake128/128/64         1566 ns         1566 ns       446976       116.927M/s
+bench_sha3::shake128/128/128        2290 ns         2290 ns       305669       106.611M/s
+bench_sha3::shake128/256/32         1980 ns         1980 ns       353556       138.726M/s
+bench_sha3::shake128/256/64         2342 ns         2342 ns       298911       130.312M/s
+bench_sha3::shake128/256/128        3066 ns         3066 ns       228320       119.443M/s
+bench_sha3::shake128/512/32         3561 ns         3561 ns       196578       145.703M/s
+bench_sha3::shake128/512/64         3917 ns         3917 ns       178652       140.229M/s
+bench_sha3::shake128/512/128        4642 ns         4642 ns       150823       131.495M/s
+bench_sha3::shake128/1024/32        5887 ns         5887 ns       118907       171.068M/s
+bench_sha3::shake128/1024/64        6249 ns         6249 ns       112010       166.042M/s
+bench_sha3::shake128/1024/128       6973 ns         6973 ns       100381       157.554M/s
+bench_sha3::shake128/2048/32       10542 ns        10542 ns        66400       188.171M/s
+bench_sha3::shake128/2048/64       10907 ns        10907 ns        64182       184.668M/s
+bench_sha3::shake128/2048/128      11628 ns        11628 ns        60201        178.47M/s
+bench_sha3::shake128/4096/32       19872 ns        19872 ns        35226       198.108M/s
+bench_sha3::shake128/4096/64       20234 ns        20234 ns        34595       196.074M/s
+bench_sha3::shake128/4096/128      20958 ns        20958 ns        33399       192.209M/s
+bench_sha3::shake256/32/32          1200 ns         1200 ns       583488       50.8777M/s
+bench_sha3::shake256/32/64          1562 ns         1562 ns       448197       58.6248M/s
+bench_sha3::shake256/32/128         2286 ns         2286 ns       306246       66.7563M/s
+bench_sha3::shake256/64/32          1194 ns         1194 ns       586453       76.7023M/s
+bench_sha3::shake256/64/64          1556 ns         1556 ns       449984        78.473M/s
+bench_sha3::shake256/64/128         2280 ns         2280 ns       307056       80.3219M/s
+bench_sha3::shake256/128/32         1184 ns         1184 ns       590988       128.829M/s
+bench_sha3::shake256/128/64         1547 ns         1546 ns       452636       118.401M/s
+bench_sha3::shake256/128/128        2271 ns         2271 ns       308291       107.526M/s
+bench_sha3::shake256/256/32         1966 ns         1966 ns       357101       139.739M/s
+bench_sha3::shake256/256/64         2327 ns         2327 ns       300591       131.147M/s
+bench_sha3::shake256/256/128        3046 ns         3046 ns       229816        120.23M/s
+bench_sha3::shake256/512/32         3521 ns         3521 ns       198762       147.338M/s
+bench_sha3::shake256/512/64         3889 ns         3889 ns       179978        141.24M/s
+bench_sha3::shake256/512/128        4616 ns         4616 ns       151751       132.236M/s
+bench_sha3::shake256/1024/32        6619 ns         6619 ns       105749       152.154M/s
+bench_sha3::shake256/1024/64        6982 ns         6982 ns       100270       148.609M/s
+bench_sha3::shake256/1024/128       7705 ns         7705 ns        90852       142.589M/s
+bench_sha3::shake256/2048/32       12824 ns        12823 ns        54587        154.69M/s
+bench_sha3::shake256/2048/64       13185 ns        13185 ns        53088       152.759M/s
+bench_sha3::shake256/2048/128      13910 ns        13909 ns        50320       149.194M/s
+bench_sha3::shake256/4096/32       24441 ns        24441 ns        28639       161.071M/s
+bench_sha3::shake256/4096/64       24804 ns        24804 ns        28220       159.948M/s
+bench_sha3::shake256/4096/128      25528 ns        25528 ns        27421       157.803M/s
 ```
 
 ### On AWS Graviton3 ( using `g++` )
 
 ```fish
-2022-12-04T08:32:30+00:00
+2022-12-05T14:07:11+00:00
 Running ./bench/a.out
 Run on (64 X 2100 MHz CPU s)
 CPU Caches:
@@ -327,93 +327,93 @@ Load Average: 0.00, 0.00, 0.00
 -----------------------------------------------------------------------------------------
 Benchmark                              Time             CPU   Iterations bytes_per_second
 -----------------------------------------------------------------------------------------
-bench_sha3::keccakf1600              629 ns          629 ns      1111085        303.01M/s
-bench_sha3::sha3_224/32              725 ns          725 ns       965070       42.0704M/s
-bench_sha3::sha3_224/64              722 ns          722 ns       969306       84.5744M/s
-bench_sha3::sha3_224/128             718 ns          718 ns       975150       170.003M/s
-bench_sha3::sha3_224/256            1426 ns         1426 ns       491069        171.21M/s
-bench_sha3::sha3_224/512            2843 ns         2843 ns       245956       171.739M/s
-bench_sha3::sha3_224/1024           5671 ns         5671 ns       123491       172.192M/s
-bench_sha3::sha3_224/2048          10607 ns        10607 ns        65995       184.143M/s
-bench_sha3::sha3_224/4096          20472 ns        20472 ns        34168       190.814M/s
-bench_sha3::sha3_256/32              699 ns          699 ns      1005574       43.6589M/s
-bench_sha3::sha3_256/64              691 ns          691 ns      1008578       88.2664M/s
-bench_sha3::sha3_256/128             691 ns          691 ns      1011001       176.649M/s
-bench_sha3::sha3_256/256            1373 ns         1373 ns       511324       177.772M/s
-bench_sha3::sha3_256/512            2745 ns         2744 ns       254866       177.913M/s
-bench_sha3::sha3_256/1024           5472 ns         5472 ns       127864       178.478M/s
-bench_sha3::sha3_256/2048          10957 ns        10957 ns        63806       178.253M/s
-bench_sha3::sha3_256/4096          21229 ns        21228 ns        33011       184.013M/s
-bench_sha3::sha3_384/32              754 ns          754 ns       930264       40.4719M/s
-bench_sha3::sha3_384/64              747 ns          747 ns       936660       81.6634M/s
-bench_sha3::sha3_384/128            1480 ns         1480 ns       472378       82.4587M/s
-bench_sha3::sha3_384/256            2232 ns         2232 ns       313351       109.363M/s
-bench_sha3::sha3_384/512            3689 ns         3689 ns       189499       132.356M/s
-bench_sha3::sha3_384/1024           7363 ns         7363 ns        95177       132.639M/s
-bench_sha3::sha3_384/2048          14690 ns        14689 ns        47575       132.961M/s
-bench_sha3::sha3_384/4096          29361 ns        29360 ns        23854       133.047M/s
-bench_sha3::sha3_512/32              726 ns          726 ns       965443       42.0351M/s
-bench_sha3::sha3_512/64              717 ns          717 ns       980229       85.1595M/s
-bench_sha3::sha3_512/128            1434 ns         1434 ns       488722       85.1051M/s
-bench_sha3::sha3_512/256            2851 ns         2851 ns       246483       85.6222M/s
-bench_sha3::sha3_512/512            5666 ns         5666 ns       123546       86.1784M/s
-bench_sha3::sha3_512/1024          10588 ns        10588 ns        66126       92.2365M/s
-bench_sha3::sha3_512/2048          20433 ns        20433 ns        34251       95.5874M/s
-bench_sha3::sha3_512/4096          40147 ns        40146 ns        17442       97.3012M/s
-bench_sha3::shake128/32/32           761 ns          761 ns       921827       80.2175M/s
-bench_sha3::shake128/32/64           787 ns          787 ns       890315       116.393M/s
-bench_sha3::shake128/32/128          836 ns          836 ns       837504       182.491M/s
-bench_sha3::shake128/64/32           767 ns          767 ns       911940       119.369M/s
-bench_sha3::shake128/64/64           793 ns          793 ns       885345       154.017M/s
-bench_sha3::shake128/64/128          841 ns          841 ns       832707       217.823M/s
-bench_sha3::shake128/128/32          764 ns          764 ns       915741       199.623M/s
-bench_sha3::shake128/128/64          786 ns          786 ns       886538       232.971M/s
-bench_sha3::shake128/128/128         836 ns          836 ns       839830       292.203M/s
-bench_sha3::shake128/256/32         1482 ns         1482 ns       472423       185.376M/s
-bench_sha3::shake128/256/64         1505 ns         1505 ns       464821       202.751M/s
-bench_sha3::shake128/256/128        1555 ns         1555 ns       450119       235.507M/s
-bench_sha3::shake128/512/32         2941 ns         2941 ns       238061       176.376M/s
-bench_sha3::shake128/512/64         2965 ns         2965 ns       236211       185.297M/s
-bench_sha3::shake128/512/128        3014 ns         3014 ns       232261       202.497M/s
-bench_sha3::shake128/1024/32        5110 ns         5110 ns       136957       197.077M/s
-bench_sha3::shake128/1024/64        5138 ns         5138 ns       136120       201.933M/s
-bench_sha3::shake128/1024/128       5200 ns         5200 ns       135071       211.283M/s
-bench_sha3::shake128/2048/32        9453 ns         9452 ns        74035       209.857M/s
-bench_sha3::shake128/2048/64        9476 ns         9476 ns        73829        212.55M/s
-bench_sha3::shake128/2048/128       9527 ns         9527 ns        73492       217.821M/s
-bench_sha3::shake128/4096/32       18129 ns        18129 ns        38613       217.156M/s
-bench_sha3::shake128/4096/64       18149 ns        18148 ns        38563       218.602M/s
-bench_sha3::shake128/4096/128      18200 ns        18199 ns        38465       221.347M/s
-bench_sha3::shake256/32/32           758 ns          758 ns       923834        80.552M/s
-bench_sha3::shake256/32/64           782 ns          782 ns       895611        117.12M/s
-bench_sha3::shake256/32/128          831 ns          831 ns       842526       183.647M/s
-bench_sha3::shake256/64/32           755 ns          755 ns       926962       121.234M/s
-bench_sha3::shake256/64/64           780 ns          780 ns       897175       156.527M/s
-bench_sha3::shake256/64/128          830 ns          830 ns       843818       220.724M/s
-bench_sha3::shake256/128/32          751 ns          751 ns       931685       203.091M/s
-bench_sha3::shake256/128/64          779 ns          779 ns       898261       234.963M/s
-bench_sha3::shake256/128/128         829 ns          829 ns       844759       294.542M/s
-bench_sha3::shake256/256/32         1473 ns         1473 ns       475036       186.438M/s
-bench_sha3::shake256/256/64         1498 ns         1498 ns       467360       203.758M/s
-bench_sha3::shake256/256/128        1547 ns         1547 ns       452450       236.666M/s
-bench_sha3::shake256/512/32         2913 ns         2913 ns       240267       178.076M/s
-bench_sha3::shake256/512/64         2938 ns         2938 ns       238258       186.968M/s
-bench_sha3::shake256/512/128        2988 ns         2987 ns       234230       204.306M/s
-bench_sha3::shake256/1024/32        5788 ns         5788 ns       120922       173.997M/s
-bench_sha3::shake256/1024/64        5813 ns         5813 ns       120399       178.488M/s
-bench_sha3::shake256/1024/128       5862 ns         5862 ns       119386       187.413M/s
-bench_sha3::shake256/2048/32       11519 ns        11518 ns        60778       172.214M/s
-bench_sha3::shake256/2048/64       11544 ns        11544 ns        60638       174.476M/s
-bench_sha3::shake256/2048/128      11595 ns        11595 ns        60371        178.98M/s
-bench_sha3::shake256/4096/32       22261 ns        22261 ns        31445       176.847M/s
-bench_sha3::shake256/4096/64       22290 ns        22290 ns        31403       177.989M/s
-bench_sha3::shake256/4096/128      22339 ns        22339 ns        31334       180.328M/s
+bench_sha3::keccakf1600              319 ns          319 ns      2192463       597.205M/s
+bench_sha3::sha3_224/32              365 ns          365 ns      1919607       83.5948M/s
+bench_sha3::sha3_224/64              356 ns          356 ns      1965801       171.452M/s
+bench_sha3::sha3_224/128             350 ns          350 ns      1999622       348.705M/s
+bench_sha3::sha3_224/256             687 ns          687 ns      1018915       355.392M/s
+bench_sha3::sha3_224/512            1359 ns         1359 ns       514875       359.209M/s
+bench_sha3::sha3_224/1024           2700 ns         2700 ns       259308       361.726M/s
+bench_sha3::sha3_224/2048           5034 ns         5034 ns       139019        387.98M/s
+bench_sha3::sha3_224/4096           9690 ns         9690 ns        72241       403.117M/s
+bench_sha3::sha3_256/32              348 ns          348 ns      2009496       87.5822M/s
+bench_sha3::sha3_256/64              342 ns          342 ns      2046215       178.432M/s
+bench_sha3::sha3_256/128             340 ns          340 ns      2061065       359.398M/s
+bench_sha3::sha3_256/256             670 ns          670 ns      1044899       364.361M/s
+bench_sha3::sha3_256/512            1331 ns         1331 ns       525928       366.879M/s
+bench_sha3::sha3_256/1024           2654 ns         2654 ns       263738       367.924M/s
+bench_sha3::sha3_256/2048           5297 ns         5297 ns       132148       368.703M/s
+bench_sha3::sha3_256/4096          10247 ns        10247 ns        68309       381.209M/s
+bench_sha3::sha3_384/32              336 ns          336 ns      2080661       90.7094M/s
+bench_sha3::sha3_384/64              337 ns          337 ns      2078858       181.258M/s
+bench_sha3::sha3_384/128             665 ns          665 ns      1053003       183.629M/s
+bench_sha3::sha3_384/256             986 ns          986 ns       709867       247.597M/s
+bench_sha3::sha3_384/512            1634 ns         1634 ns       428497        298.89M/s
+bench_sha3::sha3_384/1024           3264 ns         3264 ns       214478       299.231M/s
+bench_sha3::sha3_384/2048           6513 ns         6513 ns       107456       299.867M/s
+bench_sha3::sha3_384/4096          13011 ns        13011 ns        53800       300.232M/s
+bench_sha3::sha3_512/32              343 ns          343 ns      2040115       88.9462M/s
+bench_sha3::sha3_512/64              340 ns          340 ns      2062623       179.416M/s
+bench_sha3::sha3_512/128             668 ns          668 ns      1047836       182.735M/s
+bench_sha3::sha3_512/256            1323 ns         1323 ns       529103       184.537M/s
+bench_sha3::sha3_512/512            2635 ns         2635 ns       265663       185.311M/s
+bench_sha3::sha3_512/1024           4926 ns         4926 ns       142117       198.259M/s
+bench_sha3::sha3_512/2048           9483 ns         9483 ns        73819       205.962M/s
+bench_sha3::sha3_512/4096          18619 ns        18619 ns        37601         209.8M/s
+bench_sha3::shake128/32/32           371 ns          371 ns      1888895       164.705M/s
+bench_sha3::shake128/32/64           395 ns          395 ns      1771209       231.663M/s
+bench_sha3::shake128/32/128          444 ns          444 ns      1574927       343.306M/s
+bench_sha3::shake128/64/32           380 ns          380 ns      1841434       240.948M/s
+bench_sha3::shake128/64/64           405 ns          405 ns      1727154       301.483M/s
+bench_sha3::shake128/64/128          455 ns          455 ns      1540266       402.783M/s
+bench_sha3::shake128/128/32          370 ns          370 ns      1893894       412.856M/s
+bench_sha3::shake128/128/64          394 ns          394 ns      1776767       464.745M/s
+bench_sha3::shake128/128/128         443 ns          443 ns      1578887       550.675M/s
+bench_sha3::shake128/256/32          706 ns          706 ns       991583       389.038M/s
+bench_sha3::shake128/256/64          731 ns          731 ns       957496       417.483M/s
+bench_sha3::shake128/256/128         780 ns          780 ns       896936       469.384M/s
+bench_sha3::shake128/512/32         1381 ns         1381 ns       506935       375.666M/s
+bench_sha3::shake128/512/64         1405 ns         1405 ns       498107       390.889M/s
+bench_sha3::shake128/512/128        1455 ns         1455 ns       481190       419.596M/s
+bench_sha3::shake128/1024/32        2396 ns         2396 ns       292183       420.341M/s
+bench_sha3::shake128/1024/64        2420 ns         2420 ns       289238       428.721M/s
+bench_sha3::shake128/1024/128       2470 ns         2470 ns       283436       444.854M/s
+bench_sha3::shake128/2048/32        4407 ns         4407 ns       158828        450.08M/s
+bench_sha3::shake128/2048/64        4432 ns         4432 ns       157927       454.455M/s
+bench_sha3::shake128/2048/128       4481 ns         4481 ns       156212       463.095M/s
+bench_sha3::shake128/4096/32        8438 ns         8438 ns        82940       466.547M/s
+bench_sha3::shake128/4096/64        8465 ns         8465 ns        82705       468.683M/s
+bench_sha3::shake128/4096/128       8513 ns         8513 ns        82219       473.209M/s
+bench_sha3::shake256/32/32           380 ns          380 ns      1843462       160.674M/s
+bench_sha3::shake256/32/64           405 ns          405 ns      1727649       225.958M/s
+bench_sha3::shake256/32/128          452 ns          452 ns      1546451       337.491M/s
+bench_sha3::shake256/64/32           374 ns          374 ns      1872483       244.817M/s
+bench_sha3::shake256/64/64           398 ns          398 ns      1756423       306.462M/s
+bench_sha3::shake256/64/128          448 ns          448 ns      1563480       408.963M/s
+bench_sha3::shake256/128/32          370 ns          370 ns      1892539       412.363M/s
+bench_sha3::shake256/128/64          395 ns          395 ns      1773951        463.96M/s
+bench_sha3::shake256/128/128         444 ns          444 ns      1576696       549.755M/s
+bench_sha3::shake256/256/32          706 ns          706 ns       990915       388.831M/s
+bench_sha3::shake256/256/64          731 ns          731 ns       956988       417.214M/s
+bench_sha3::shake256/256/128         781 ns          781 ns       896651       469.071M/s
+bench_sha3::shake256/512/32         1381 ns         1380 ns       507216       375.809M/s
+bench_sha3::shake256/512/64         1406 ns         1406 ns       497985       390.819M/s
+bench_sha3::shake256/512/128        1455 ns         1455 ns       481259        419.59M/s
+bench_sha3::shake256/1024/32        2724 ns         2724 ns       256919       369.661M/s
+bench_sha3::shake256/1024/64        2749 ns         2749 ns       254597       377.414M/s
+bench_sha3::shake256/1024/128       2798 ns         2798 ns       250200       392.697M/s
+bench_sha3::shake256/2048/32        5418 ns         5418 ns       129192       366.151M/s
+bench_sha3::shake256/2048/64        5443 ns         5443 ns       128621       370.057M/s
+bench_sha3::shake256/2048/128       5493 ns         5493 ns       127429       377.815M/s
+bench_sha3::shake256/4096/32       10451 ns        10451 ns        66971       376.693M/s
+bench_sha3::shake256/4096/64       10475 ns        10474 ns        66826       378.762M/s
+bench_sha3::shake256/4096/128      10524 ns        10523 ns        66509       382.797M/s
 ```
 
 ### On AWS Graviton3 ( using `clang++` )
 
 ```fish
-2022-12-04T08:34:57+00:00
+2022-12-05T14:09:25+00:00
 Running ./bench/a.out
 Run on (64 X 2100 MHz CPU s)
 CPU Caches:
@@ -421,97 +421,97 @@ CPU Caches:
   L1 Instruction 64 KiB (x64)
   L2 Unified 1024 KiB (x64)
   L3 Unified 32768 KiB (x1)
-Load Average: 0.26, 0.18, 0.07
+Load Average: 0.37, 0.21, 0.09
 -----------------------------------------------------------------------------------------
 Benchmark                              Time             CPU   Iterations bytes_per_second
 -----------------------------------------------------------------------------------------
-bench_sha3::keccakf1600              459 ns          459 ns      1525865       415.789M/s
-bench_sha3::sha3_224/32              474 ns          474 ns      1477756       64.4352M/s
-bench_sha3::sha3_224/64              470 ns          470 ns      1489834        129.92M/s
-bench_sha3::sha3_224/128             466 ns          466 ns      1503524       262.215M/s
-bench_sha3::sha3_224/256             924 ns          924 ns       757322       264.152M/s
-bench_sha3::sha3_224/512            1843 ns         1843 ns       379801       264.898M/s
-bench_sha3::sha3_224/1024           3689 ns         3688 ns       189787       264.761M/s
-bench_sha3::sha3_224/2048           6899 ns         6899 ns       101456       283.097M/s
-bench_sha3::sha3_224/4096          13315 ns        13315 ns        52575       293.375M/s
-bench_sha3::sha3_256/32              475 ns          475 ns      1474436       64.2738M/s
-bench_sha3::sha3_256/64              471 ns          471 ns      1486340       129.582M/s
-bench_sha3::sha3_256/128             465 ns          465 ns      1503830       262.243M/s
-bench_sha3::sha3_256/256             925 ns          925 ns       756859       264.026M/s
-bench_sha3::sha3_256/512            1842 ns         1842 ns       379990       265.056M/s
-bench_sha3::sha3_256/1024           3688 ns         3688 ns       189823       264.785M/s
-bench_sha3::sha3_256/2048           7362 ns         7362 ns        95081       265.309M/s
-bench_sha3::sha3_256/4096          14240 ns        14240 ns        49158       274.313M/s
-bench_sha3::sha3_384/32              472 ns          472 ns      1482101        64.606M/s
-bench_sha3::sha3_384/64              470 ns          470 ns      1489406        129.87M/s
-bench_sha3::sha3_384/128             927 ns          927 ns       754747       131.638M/s
-bench_sha3::sha3_384/256            1384 ns         1384 ns       505991       176.453M/s
-bench_sha3::sha3_384/512            2298 ns         2298 ns       304661       212.523M/s
-bench_sha3::sha3_384/1024           4601 ns         4601 ns       152147       212.243M/s
-bench_sha3::sha3_384/2048           9191 ns         9191 ns        76168       212.511M/s
-bench_sha3::sha3_384/4096          18354 ns        18354 ns        38140       212.829M/s
-bench_sha3::sha3_512/32              471 ns          471 ns      1486521       64.8079M/s
-bench_sha3::sha3_512/64              466 ns          466 ns      1506053       130.896M/s
-bench_sha3::sha3_512/128             923 ns          923 ns       758492       132.279M/s
-bench_sha3::sha3_512/256            1836 ns         1836 ns       381251       132.974M/s
-bench_sha3::sha3_512/512            3677 ns         3677 ns       190378       132.804M/s
-bench_sha3::sha3_512/1024           6878 ns         6878 ns       101765       141.981M/s
-bench_sha3::sha3_512/2048          13279 ns        13278 ns        52716       147.091M/s
-bench_sha3::sha3_512/4096          26090 ns        26090 ns        26829       149.724M/s
-bench_sha3::shake128/32/32           585 ns          585 ns      1195968       104.309M/s
-bench_sha3::shake128/32/64           694 ns          694 ns      1008351       131.876M/s
-bench_sha3::shake128/32/128          909 ns          909 ns       769753       167.797M/s
-bench_sha3::shake128/64/32           586 ns          586 ns      1194395        156.21M/s
-bench_sha3::shake128/64/64           694 ns          694 ns      1007178       175.779M/s
-bench_sha3::shake128/64/128          911 ns          911 ns       768116       200.977M/s
-bench_sha3::shake128/128/32          582 ns          582 ns      1203460       262.267M/s
-bench_sha3::shake128/128/64          690 ns          690 ns      1014076       265.298M/s
-bench_sha3::shake128/128/128         907 ns          907 ns       771572       269.138M/s
-bench_sha3::shake128/256/32         1040 ns         1040 ns       673404       264.206M/s
-bench_sha3::shake128/256/64         1150 ns         1150 ns       609600       265.466M/s
-bench_sha3::shake128/256/128        1372 ns         1372 ns       510024       266.851M/s
-bench_sha3::shake128/512/32         1966 ns         1966 ns       355943       263.835M/s
-bench_sha3::shake128/512/64         2077 ns         2077 ns       336976       264.465M/s
-bench_sha3::shake128/512/128        2297 ns         2297 ns       304739       265.677M/s
-bench_sha3::shake128/1024/32        3343 ns         3342 ns       209432       301.305M/s
-bench_sha3::shake128/1024/64        3453 ns         3453 ns       202721         300.5M/s
-bench_sha3::shake128/1024/128       3673 ns         3673 ns       190580        299.11M/s
-bench_sha3::shake128/2048/32        6103 ns         6103 ns       114711       325.052M/s
-bench_sha3::shake128/2048/64        6211 ns         6211 ns       112707       324.294M/s
-bench_sha3::shake128/2048/128       6428 ns         6427 ns       108911       322.866M/s
-bench_sha3::shake128/4096/32       11612 ns        11611 ns        60281       339.046M/s
-bench_sha3::shake128/4096/64       11721 ns        11721 ns        59724       338.486M/s
-bench_sha3::shake128/4096/128      11937 ns        11936 ns        58641       337.484M/s
-bench_sha3::shake256/32/32           589 ns          589 ns      1187791       103.588M/s
-bench_sha3::shake256/32/64           698 ns          698 ns      1003403       131.244M/s
-bench_sha3::shake256/32/128          914 ns          914 ns       766112       167.002M/s
-bench_sha3::shake256/64/32           584 ns          584 ns      1198856       156.801M/s
-bench_sha3::shake256/64/64           693 ns          693 ns      1011252       176.192M/s
-bench_sha3::shake256/64/128          908 ns          908 ns       770610       201.562M/s
-bench_sha3::shake256/128/32          579 ns          579 ns      1209134       263.564M/s
-bench_sha3::shake256/128/64          688 ns          688 ns      1018046       266.262M/s
-bench_sha3::shake256/128/128         904 ns          904 ns       774426       270.117M/s
-bench_sha3::shake256/256/32         1038 ns         1038 ns       674437       264.577M/s
-bench_sha3::shake256/256/64         1147 ns         1147 ns       610512       266.168M/s
-bench_sha3::shake256/256/128        1362 ns         1362 ns       513831       268.802M/s
-bench_sha3::shake256/512/32         1955 ns         1955 ns       358076       265.388M/s
-bench_sha3::shake256/512/64         2063 ns         2063 ns       339251       266.239M/s
-bench_sha3::shake256/512/128        2279 ns         2279 ns       307130       267.789M/s
-bench_sha3::shake256/1024/32        3798 ns         3798 ns       184282       265.159M/s
-bench_sha3::shake256/1024/64        3907 ns         3907 ns       179223       265.583M/s
-bench_sha3::shake256/1024/128       4121 ns         4121 ns       169847        266.57M/s
-bench_sha3::shake256/2048/32        7471 ns         7471 ns        93699       265.521M/s
-bench_sha3::shake256/2048/64        7579 ns         7579 ns        92356       265.751M/s
-bench_sha3::shake256/2048/128       7795 ns         7795 ns        89782       266.235M/s
-bench_sha3::shake256/4096/32       14343 ns        14342 ns        48816       274.485M/s
-bench_sha3::shake256/4096/64       14450 ns        14450 ns        48441       274.557M/s
-bench_sha3::shake256/4096/128      14664 ns        14664 ns        47736       274.707M/s
+bench_sha3::keccakf1600              326 ns          326 ns      2148549       585.367M/s
+bench_sha3::sha3_224/32              352 ns          352 ns      1991179       86.8119M/s
+bench_sha3::sha3_224/64              351 ns          351 ns      1995946       174.022M/s
+bench_sha3::sha3_224/128             346 ns          346 ns      2023580       352.899M/s
+bench_sha3::sha3_224/256             679 ns          679 ns      1030890       359.469M/s
+bench_sha3::sha3_224/512            1351 ns         1351 ns       518103       361.499M/s
+bench_sha3::sha3_224/1024           2698 ns         2698 ns       259436        361.93M/s
+bench_sha3::sha3_224/2048           5035 ns         5035 ns       139035       387.886M/s
+bench_sha3::sha3_224/4096           9711 ns         9711 ns        72076       402.243M/s
+bench_sha3::sha3_256/32              348 ns          348 ns      2010439       87.6812M/s
+bench_sha3::sha3_256/64              348 ns          348 ns      2014004       175.573M/s
+bench_sha3::sha3_256/128             342 ns          342 ns      2043948       356.468M/s
+bench_sha3::sha3_256/256             676 ns          676 ns      1035220       361.074M/s
+bench_sha3::sha3_256/512            1346 ns         1346 ns       520041       362.824M/s
+bench_sha3::sha3_256/1024           2693 ns         2693 ns       259954       362.622M/s
+bench_sha3::sha3_256/2048           5365 ns         5365 ns       130584       364.026M/s
+bench_sha3::sha3_256/4096          10371 ns        10371 ns        67496       376.659M/s
+bench_sha3::sha3_384/32              348 ns          348 ns      2009206       87.5781M/s
+bench_sha3::sha3_384/64              349 ns          349 ns      2005771        174.92M/s
+bench_sha3::sha3_384/128             677 ns          677 ns      1034186        180.34M/s
+bench_sha3::sha3_384/256            1010 ns         1010 ns       693297       241.817M/s
+bench_sha3::sha3_384/512            1675 ns         1675 ns       418040       291.585M/s
+bench_sha3::sha3_384/1024           3351 ns         3351 ns       208967       291.393M/s
+bench_sha3::sha3_384/2048           6690 ns         6690 ns       104637        291.95M/s
+bench_sha3::sha3_384/4096          13354 ns        13354 ns        52439       292.516M/s
+bench_sha3::sha3_512/32              347 ns          347 ns      2016755       87.9357M/s
+bench_sha3::sha3_512/64              343 ns          343 ns      2045416       178.187M/s
+bench_sha3::sha3_512/128             672 ns          672 ns      1041283       181.555M/s
+bench_sha3::sha3_512/256            1338 ns         1338 ns       523325       182.503M/s
+bench_sha3::sha3_512/512            2678 ns         2678 ns       261362       182.338M/s
+bench_sha3::sha3_512/1024           5005 ns         5005 ns       139863       195.137M/s
+bench_sha3::sha3_512/2048           9652 ns         9652 ns        72523        202.35M/s
+bench_sha3::sha3_512/4096          18956 ns        18955 ns        36921       206.075M/s
+bench_sha3::shake128/32/32           462 ns          462 ns      1516140       132.207M/s
+bench_sha3::shake128/32/64           567 ns          567 ns      1233411       161.331M/s
+bench_sha3::shake128/32/128          783 ns          783 ns       894200       194.909M/s
+bench_sha3::shake128/64/32           463 ns          463 ns      1510364       197.554M/s
+bench_sha3::shake128/64/64           571 ns          571 ns      1229931       213.784M/s
+bench_sha3::shake128/64/128          785 ns          785 ns       891876       233.305M/s
+bench_sha3::shake128/128/32          459 ns          459 ns      1525308       332.484M/s
+bench_sha3::shake128/128/64          567 ns          567 ns      1235485       323.196M/s
+bench_sha3::shake128/128/128         781 ns          781 ns       896606       312.752M/s
+bench_sha3::shake128/256/32          791 ns          791 ns       884359        347.04M/s
+bench_sha3::shake128/256/64          900 ns          900 ns       778053       339.222M/s
+bench_sha3::shake128/256/128        1114 ns         1114 ns       628255       328.686M/s
+bench_sha3::shake128/512/32         1465 ns         1465 ns       477913       354.133M/s
+bench_sha3::shake128/512/64         1573 ns         1573 ns       444947       349.219M/s
+bench_sha3::shake128/512/128        1788 ns         1788 ns       391584        341.45M/s
+bench_sha3::shake128/1024/32        2465 ns         2465 ns       283909       408.484M/s
+bench_sha3::shake128/1024/64        2574 ns         2574 ns       271976       403.154M/s
+bench_sha3::shake128/1024/128       2789 ns         2788 ns       251034       393.992M/s
+bench_sha3::shake128/2048/32        4477 ns         4476 ns       156398        443.13M/s
+bench_sha3::shake128/2048/64        4584 ns         4584 ns       152718       439.425M/s
+bench_sha3::shake128/2048/128       4800 ns         4799 ns       145851       432.384M/s
+bench_sha3::shake128/4096/32        8494 ns         8494 ns        82418       463.478M/s
+bench_sha3::shake128/4096/64        8604 ns         8603 ns        81374       461.131M/s
+bench_sha3::shake128/4096/128       8817 ns         8817 ns        79393        456.88M/s
+bench_sha3::shake256/32/32           465 ns          465 ns      1505648       131.348M/s
+bench_sha3::shake256/32/64           573 ns          573 ns      1222103       159.839M/s
+bench_sha3::shake256/32/128          786 ns          786 ns       890466       194.119M/s
+bench_sha3::shake256/64/32           461 ns          461 ns      1517626       198.484M/s
+bench_sha3::shake256/64/64           572 ns          572 ns      1229657       213.463M/s
+bench_sha3::shake256/64/128          783 ns          783 ns       894278        233.91M/s
+bench_sha3::shake256/128/32          456 ns          456 ns      1536298        334.88M/s
+bench_sha3::shake256/128/64          563 ns          563 ns      1244182       325.442M/s
+bench_sha3::shake256/128/128         779 ns          779 ns       898890       313.507M/s
+bench_sha3::shake256/256/32          789 ns          789 ns       886973        348.06M/s
+bench_sha3::shake256/256/64          897 ns          897 ns       780241       340.176M/s
+bench_sha3::shake256/256/128        1112 ns         1112 ns       629395       329.241M/s
+bench_sha3::shake256/512/32         1457 ns         1457 ns       480328       355.996M/s
+bench_sha3::shake256/512/64         1565 ns         1565 ns       447242       350.967M/s
+bench_sha3::shake256/512/128        1780 ns         1780 ns       393174       342.814M/s
+bench_sha3::shake256/1024/32        2804 ns         2804 ns       249658       359.186M/s
+bench_sha3::shake256/1024/64        2911 ns         2911 ns       240468       356.401M/s
+bench_sha3::shake256/1024/128       3127 ns         3127 ns       223819        351.31M/s
+bench_sha3::shake256/2048/32        5481 ns         5480 ns       127706       361.949M/s
+bench_sha3::shake256/2048/64        5587 ns         5587 ns       125290       360.514M/s
+bench_sha3::shake256/2048/128       5804 ns         5804 ns       120611       357.574M/s
+bench_sha3::shake256/4096/32       10492 ns        10492 ns        66722       375.233M/s
+bench_sha3::shake256/4096/64       10598 ns        10598 ns        66045       374.334M/s
+bench_sha3::shake256/4096/128      10815 ns        10815 ns        64721       372.474M/s
 ```
 
 ### On Intel(R) Xeon(R) CPU E5-2686 v4 @ 2.30GHz ( using `g++` )
 
 ```fish
-2022-12-04T08:37:09+00:00
+2022-12-05T14:11:51+00:00
 Running ./bench/a.out
 Run on (4 X 2300.25 MHz CPU s)
 CPU Caches:
@@ -519,97 +519,97 @@ CPU Caches:
   L1 Instruction 32 KiB (x2)
   L2 Unified 256 KiB (x2)
   L3 Unified 46080 KiB (x1)
-Load Average: 0.13, 0.03, 0.01
+Load Average: 0.08, 0.02, 0.01
 ------------------------------------------------------------------------------------------------------------
 Benchmark                              Time             CPU   Iterations average_cpu_cycles bytes_per_second
 ------------------------------------------------------------------------------------------------------------
-bench_sha3::keccakf1600             1336 ns         1336 ns       524560             3.047k       142.794M/s
-bench_sha3::sha3_224/32             1109 ns         1109 ns       628047             2.513k       27.5214M/s
-bench_sha3::sha3_224/64             1109 ns         1109 ns       631883             2.513k       55.0437M/s
-bench_sha3::sha3_224/128            1106 ns         1106 ns       633912             2.505k       110.408M/s
-bench_sha3::sha3_224/256            2175 ns         2175 ns       321854             4.965k       112.245M/s
-bench_sha3::sha3_224/512            4320 ns         4319 ns       162196             9.897k       113.042M/s
-bench_sha3::sha3_224/1024           8573 ns         8573 ns        81642            19.682k        113.91M/s
-bench_sha3::sha3_224/2048          16068 ns        16068 ns        43450             36.92k       121.557M/s
-bench_sha3::sha3_224/4096          31017 ns        31017 ns        22534            71.304k        125.94M/s
-bench_sha3::sha3_256/32             1155 ns         1155 ns       606164             2.618k         26.42M/s
-bench_sha3::sha3_256/64             1156 ns         1156 ns       605897             2.619k       52.8112M/s
-bench_sha3::sha3_256/128            1162 ns         1162 ns       602718             2.633k       105.071M/s
-bench_sha3::sha3_256/256            2275 ns         2274 ns       307624             5.192k       107.339M/s
-bench_sha3::sha3_256/512            4573 ns         4573 ns       153275            10.479k       106.772M/s
-bench_sha3::sha3_256/1024           9125 ns         9125 ns        76748             20.95k       107.024M/s
-bench_sha3::sha3_256/2048          18241 ns        18241 ns        38394            41.915k       107.074M/s
-bench_sha3::sha3_256/4096          35275 ns        35273 ns        19833            81.087k       110.742M/s
-bench_sha3::sha3_384/32             1102 ns         1102 ns       635856             2.496k       27.6952M/s
-bench_sha3::sha3_384/64             1102 ns         1102 ns       635710             2.494k       55.4066M/s
-bench_sha3::sha3_384/128            2157 ns         2157 ns       324392             4.924k       56.5833M/s
-bench_sha3::sha3_384/256            3202 ns         3202 ns       218457             7.327k        76.254M/s
-bench_sha3::sha3_384/512            5311 ns         5310 ns       131496            12.176k       91.9464M/s
-bench_sha3::sha3_384/1024          10579 ns        10579 ns        66243            24.293k        92.315M/s
-bench_sha3::sha3_384/2048          21119 ns        21116 ns        33175            48.523k        92.495M/s
-bench_sha3::sha3_384/4096          42108 ns        42106 ns        16634            96.799k       92.7719M/s
-bench_sha3::sha3_512/32             1105 ns         1105 ns       633035             2.502k       27.6183M/s
-bench_sha3::sha3_512/64             1101 ns         1101 ns       635885             2.492k       55.4409M/s
-bench_sha3::sha3_512/128            2176 ns         2176 ns       321695             4.967k       56.0924M/s
-bench_sha3::sha3_512/256            4313 ns         4313 ns       162701              9.88k       56.6082M/s
-bench_sha3::sha3_512/512            8569 ns         8568 ns        81722            19.668k       56.9878M/s
-bench_sha3::sha3_512/1024          15992 ns        15992 ns        43767            36.738k       61.0639M/s
-bench_sha3::sha3_512/2048          30862 ns        30859 ns        22666            70.931k       63.2918M/s
-bench_sha3::sha3_512/4096          60556 ns        60555 ns        11559           139.236k       64.5078M/s
-bench_sha3::shake128/32/32          1478 ns         1478 ns       472524             3.373k       41.2972M/s
-bench_sha3::shake128/32/64          1513 ns         1513 ns       462952             3.458k       60.5157M/s
-bench_sha3::shake128/32/128         1568 ns         1568 ns       446404             3.585k       97.3034M/s
-bench_sha3::shake128/64/32          1478 ns         1478 ns       472079             3.372k       61.9487M/s
-bench_sha3::shake128/64/64          1507 ns         1506 ns       464019             3.443k       81.0328M/s
-bench_sha3::shake128/64/128         1562 ns         1562 ns       448113             3.572k       117.198M/s
-bench_sha3::shake128/128/32         1472 ns         1472 ns       475581             3.359k       103.679M/s
-bench_sha3::shake128/128/64         1512 ns         1512 ns       462651             3.456k       121.092M/s
-bench_sha3::shake128/128/128        1559 ns         1559 ns       448800             3.564k       156.593M/s
-bench_sha3::shake128/256/32         2866 ns         2866 ns       244420             6.565k       95.8469M/s
-bench_sha3::shake128/256/64         2908 ns         2908 ns       238361             6.668k        104.93M/s
-bench_sha3::shake128/256/128        2961 ns         2961 ns       236320             6.788k       123.694M/s
-bench_sha3::shake128/512/32         5742 ns         5742 ns       121997             13.18k       90.3489M/s
-bench_sha3::shake128/512/64         5771 ns         5771 ns       121140            13.252k       95.1813M/s
-bench_sha3::shake128/512/128        5821 ns         5821 ns       120349            13.366k       104.861M/s
-bench_sha3::shake128/1024/32        9974 ns         9974 ns        69978            22.914k       100.975M/s
-bench_sha3::shake128/1024/64       10031 ns        10031 ns        69813            23.048k       103.444M/s
-bench_sha3::shake128/1024/128      10061 ns        10061 ns        69496            23.119k       109.196M/s
-bench_sha3::shake128/2048/32       18525 ns        18524 ns        37774             42.58k       107.084M/s
-bench_sha3::shake128/2048/64       18538 ns        18537 ns        37747            42.613k       108.656M/s
-bench_sha3::shake128/2048/128      18594 ns        18594 ns        37591            42.742k       111.608M/s
-bench_sha3::shake128/4096/32       35530 ns        35529 ns        19690            81.693k       110.806M/s
-bench_sha3::shake128/4096/64       35559 ns        35558 ns        19664            81.759k       111.574M/s
-bench_sha3::shake128/4096/128      35594 ns        35593 ns        19625             81.84k       113.177M/s
-bench_sha3::shake256/32/32          1330 ns         1330 ns       526433             3.037k       45.8975M/s
-bench_sha3::shake256/32/64          1371 ns         1370 ns       510515              3.13k       66.8034M/s
-bench_sha3::shake256/32/128         1427 ns         1427 ns       490794              3.26k       106.941M/s
-bench_sha3::shake256/64/32          1334 ns         1334 ns       525015             3.046k       68.6385M/s
-bench_sha3::shake256/64/64          1368 ns         1368 ns       510377             3.125k       89.2164M/s
-bench_sha3::shake256/64/128         1424 ns         1424 ns       491717             3.253k        128.59M/s
-bench_sha3::shake256/128/32         1325 ns         1325 ns       528523             3.025k       115.171M/s
-bench_sha3::shake256/128/64         1359 ns         1359 ns       515073             3.103k       134.763M/s
-bench_sha3::shake256/128/128        1415 ns         1415 ns       494772             3.234k       172.502M/s
-bench_sha3::shake256/256/32         2592 ns         2592 ns       269991             5.939k       105.979M/s
-bench_sha3::shake256/256/64         2630 ns         2630 ns       266230             6.026k       116.053M/s
-bench_sha3::shake256/256/128        2676 ns         2676 ns       261593             6.134k       136.829M/s
-bench_sha3::shake256/512/32         5133 ns         5132 ns       136469            11.784k       101.086M/s
-bench_sha3::shake256/512/64         5174 ns         5174 ns       135408            11.878k       106.174M/s
-bench_sha3::shake256/512/128        5226 ns         5226 ns       133896            11.999k       116.784M/s
-bench_sha3::shake256/1024/32       10257 ns        10256 ns        68298            23.569k       98.1905M/s
-bench_sha3::shake256/1024/64       10280 ns        10280 ns        68108            23.622k       100.932M/s
-bench_sha3::shake256/1024/128      10342 ns        10341 ns        67692            23.766k       106.237M/s
-bench_sha3::shake256/2048/32       20472 ns        20472 ns        34182            47.064k        96.895M/s
-bench_sha3::shake256/2048/64       20502 ns        20501 ns        34136            47.133k       98.2454M/s
-bench_sha3::shake256/2048/128      20571 ns        20571 ns        34031            47.288k        100.88M/s
-bench_sha3::shake256/4096/32       39638 ns        39637 ns        17654            91.144k       99.3214M/s
-bench_sha3::shake256/4096/64       39660 ns        39659 ns        17647            91.194k       100.035M/s
-bench_sha3::shake256/4096/128      39725 ns        39723 ns        17623             91.34k        101.41M/s
+bench_sha3::keccakf1600              580 ns          580 ns      1205838             1.309k       329.111M/s
+bench_sha3::sha3_224/32              635 ns          635 ns      1102375             1.423k        48.078M/s
+bench_sha3::sha3_224/64              634 ns          634 ns      1104289             1.421k       96.3255M/s
+bench_sha3::sha3_224/128             633 ns          633 ns      1106382             1.418k       192.887M/s
+bench_sha3::sha3_224/256            1229 ns         1229 ns       569017             2.792k       198.601M/s
+bench_sha3::sha3_224/512            2417 ns         2417 ns       289390             5.523k       202.025M/s
+bench_sha3::sha3_224/1024           4794 ns         4794 ns       146030            10.989k       203.708M/s
+bench_sha3::sha3_224/2048           8973 ns         8973 ns        78034            20.602k       217.677M/s
+bench_sha3::sha3_224/4096          17327 ns        17327 ns        40379            39.809k       225.439M/s
+bench_sha3::sha3_256/32              628 ns          628 ns      1117063             1.407k       48.6099M/s
+bench_sha3::sha3_256/64              626 ns          626 ns      1114960             1.404k        97.442M/s
+bench_sha3::sha3_256/128             622 ns          622 ns      1126533             1.393k       196.388M/s
+bench_sha3::sha3_256/256            1214 ns         1214 ns       576945             2.756k       201.062M/s
+bench_sha3::sha3_256/512            2400 ns         2400 ns       291505             5.483k       203.462M/s
+bench_sha3::sha3_256/1024           4762 ns         4762 ns       146906            10.916k       205.079M/s
+bench_sha3::sha3_256/2048           9478 ns         9478 ns        73822            21.763k        206.08M/s
+bench_sha3::sha3_256/4096          18378 ns        18377 ns        38105            42.225k       212.556M/s
+bench_sha3::sha3_384/32              635 ns          635 ns      1101695             1.426k       48.0423M/s
+bench_sha3::sha3_384/64              633 ns          633 ns      1106657             1.421k       96.4342M/s
+bench_sha3::sha3_384/128            1223 ns         1223 ns       572559             2.778k       99.7815M/s
+bench_sha3::sha3_384/256            1809 ns         1809 ns       387170             4.125k        134.98M/s
+bench_sha3::sha3_384/512            2982 ns         2982 ns       234761             6.825k       163.734M/s
+bench_sha3::sha3_384/1024           5935 ns         5935 ns       117618            13.617k       164.544M/s
+bench_sha3::sha3_384/2048          11822 ns        11821 ns        59227            27.154k       165.227M/s
+bench_sha3::sha3_384/4096          23583 ns        23581 ns        29694            54.205k       165.652M/s
+bench_sha3::sha3_512/32              604 ns          604 ns      1157715             1.351k       50.5473M/s
+bench_sha3::sha3_512/64              604 ns          604 ns      1159672             1.352k       101.082M/s
+bench_sha3::sha3_512/128            1164 ns         1164 ns       601628              2.64k       104.878M/s
+bench_sha3::sha3_512/256            2281 ns         2281 ns       306718             5.209k       107.047M/s
+bench_sha3::sha3_512/512            4527 ns         4527 ns       154606            10.376k       107.853M/s
+bench_sha3::sha3_512/1024           8438 ns         8437 ns        83017             19.37k       115.744M/s
+bench_sha3::sha3_512/2048          16287 ns        16286 ns        42974            37.421k       119.927M/s
+bench_sha3::sha3_512/4096          31946 ns        31944 ns        21911            73.431k       122.283M/s
+bench_sha3::shake128/32/32           664 ns          664 ns      1057050             1.504k       91.9465M/s
+bench_sha3::shake128/32/64           697 ns          697 ns      1004142             1.581k       131.336M/s
+bench_sha3::shake128/32/128          753 ns          753 ns       929504             1.709k       202.674M/s
+bench_sha3::shake128/64/32           654 ns          654 ns      1069622             1.481k       140.023M/s
+bench_sha3::shake128/64/64           688 ns          688 ns      1019682              1.56k       177.547M/s
+bench_sha3::shake128/64/128          743 ns          743 ns       943099             1.687k       246.439M/s
+bench_sha3::shake128/128/32          649 ns          649 ns      1077806              1.47k       234.998M/s
+bench_sha3::shake128/128/64          686 ns          686 ns      1019411             1.556k       266.896M/s
+bench_sha3::shake128/128/128         740 ns          740 ns       944450              1.68k       329.787M/s
+bench_sha3::shake128/256/32         1249 ns         1249 ns       560110              2.85k       219.947M/s
+bench_sha3::shake128/256/64         1283 ns         1283 ns       545922             2.929k       237.844M/s
+bench_sha3::shake128/256/128        1340 ns         1340 ns       522339              3.06k        273.29M/s
+bench_sha3::shake128/512/32         2443 ns         2443 ns       286755             5.595k         212.4M/s
+bench_sha3::shake128/512/64         2470 ns         2470 ns       283476             5.659k       222.367M/s
+bench_sha3::shake128/512/128        2527 ns         2527 ns       277025             5.789k       241.556M/s
+bench_sha3::shake128/1024/32        4223 ns         4223 ns       165785             9.689k       238.497M/s
+bench_sha3::shake128/1024/64        4253 ns         4253 ns       164550              9.76k       243.981M/s
+bench_sha3::shake128/1024/128       4311 ns         4311 ns       162362             9.893k       254.864M/s
+bench_sha3::shake128/2048/32        7780 ns         7780 ns        90130            17.871k       254.976M/s
+bench_sha3::shake128/2048/64        7807 ns         7806 ns        89682            17.933k       258.021M/s
+bench_sha3::shake128/2048/128       7871 ns         7870 ns        88990             18.08k       263.669M/s
+bench_sha3::shake128/4096/32       14908 ns        14908 ns        46944            34.255k       264.079M/s
+bench_sha3::shake128/4096/64       14929 ns        14929 ns        46887            34.307k       265.752M/s
+bench_sha3::shake128/4096/128      14990 ns        14989 ns        46649            34.447k       268.756M/s
+bench_sha3::shake256/32/32           653 ns          653 ns      1072085              1.48k       93.4497M/s
+bench_sha3::shake256/32/64           687 ns          687 ns      1019952             1.556k       133.361M/s
+bench_sha3::shake256/32/128          743 ns          743 ns       942336             1.686k       205.371M/s
+bench_sha3::shake256/64/32           652 ns          652 ns      1073999             1.477k       140.448M/s
+bench_sha3::shake256/64/64           686 ns          686 ns      1019071             1.556k       177.924M/s
+bench_sha3::shake256/64/128          742 ns          742 ns       943990             1.684k       246.754M/s
+bench_sha3::shake256/128/32          645 ns          645 ns      1083458              1.46k       236.588M/s
+bench_sha3::shake256/128/64          677 ns          677 ns      1033457             1.535k       270.451M/s
+bench_sha3::shake256/128/128         734 ns          734 ns       954482             1.665k       332.733M/s
+bench_sha3::shake256/256/32         1234 ns         1234 ns       568016             2.815k       222.638M/s
+bench_sha3::shake256/256/64         1266 ns         1266 ns       552955             2.889k       241.066M/s
+bench_sha3::shake256/256/128        1322 ns         1322 ns       529555             3.018k       277.087M/s
+bench_sha3::shake256/512/32         2420 ns         2420 ns       288914             5.542k        214.42M/s
+bench_sha3::shake256/512/64         2457 ns         2457 ns       285357             5.629k       223.565M/s
+bench_sha3::shake256/512/128        2510 ns         2510 ns       279001             5.749k       243.208M/s
+bench_sha3::shake256/1024/32        4783 ns         4782 ns       146385            10.977k       210.577M/s
+bench_sha3::shake256/1024/64        4816 ns         4816 ns       145353            11.055k       215.465M/s
+bench_sha3::shake256/1024/128       4870 ns         4870 ns       143694             11.18k       225.581M/s
+bench_sha3::shake256/2048/32        9498 ns         9497 ns        73718            21.822k       208.874M/s
+bench_sha3::shake256/2048/64        9523 ns         9523 ns        73517             21.88k       211.505M/s
+bench_sha3::shake256/2048/128       9577 ns         9577 ns        73117            22.004k       216.689M/s
+bench_sha3::shake256/4096/32       18365 ns        18363 ns        38115            42.201k       214.383M/s
+bench_sha3::shake256/4096/64       18409 ns        18408 ns        38013            42.303k       215.517M/s
+bench_sha3::shake256/4096/128      18483 ns        18482 ns        37888            42.472k       217.961M/s
 ```
 
 ### On Intel(R) Xeon(R) CPU E5-2686 v4 @ 2.30GHz ( using `clang++` )
 
 ```fish
-2022-12-04T08:39:47+00:00
+2022-12-05T14:14:08+00:00
 Running ./bench/a.out
 Run on (4 X 2300.25 MHz CPU s)
 CPU Caches:
@@ -617,91 +617,91 @@ CPU Caches:
   L1 Instruction 32 KiB (x2)
   L2 Unified 256 KiB (x2)
   L3 Unified 46080 KiB (x1)
-Load Average: 0.26, 0.20, 0.09
+Load Average: 0.32, 0.20, 0.08
 ------------------------------------------------------------------------------------------------------------
 Benchmark                              Time             CPU   Iterations average_cpu_cycles bytes_per_second
 ------------------------------------------------------------------------------------------------------------
-bench_sha3::keccakf1600              491 ns          491 ns      1425023             1.101k       388.771M/s
-bench_sha3::sha3_224/32              516 ns          516 ns      1355114             1.159k       59.1475M/s
-bench_sha3::sha3_224/64              515 ns          515 ns      1360671             1.157k       118.477M/s
-bench_sha3::sha3_224/128             511 ns          511 ns      1371388             1.148k       238.938M/s
-bench_sha3::sha3_224/256            1002 ns         1002 ns       696561             2.278k       243.606M/s
-bench_sha3::sha3_224/512            1990 ns         1989 ns       351893             4.549k       245.432M/s
-bench_sha3::sha3_224/1024           3952 ns         3952 ns       177010             9.063k       247.083M/s
-bench_sha3::sha3_224/2048           7365 ns         7365 ns        95139            16.912k       265.196M/s
-bench_sha3::sha3_224/4096          14237 ns        14237 ns        49222            32.718k       274.376M/s
-bench_sha3::sha3_256/32              514 ns          514 ns      1361288             1.152k       59.3709M/s
-bench_sha3::sha3_256/64              516 ns          516 ns      1358727             1.156k       118.313M/s
-bench_sha3::sha3_256/128             513 ns          513 ns      1361566              1.15k       237.843M/s
-bench_sha3::sha3_256/256            1007 ns         1007 ns       695253             2.286k       242.377M/s
-bench_sha3::sha3_256/512            1989 ns         1989 ns       351682             4.545k       245.435M/s
-bench_sha3::sha3_256/1024           3948 ns         3948 ns       177203              9.05k       247.379M/s
-bench_sha3::sha3_256/2048           7856 ns         7856 ns        88918            18.039k       248.618M/s
-bench_sha3::sha3_256/4096          15238 ns        15236 ns        45975            35.019k       256.381M/s
-bench_sha3::sha3_384/32              518 ns          518 ns      1353909             1.159k       58.9091M/s
-bench_sha3::sha3_384/64              518 ns          518 ns      1353049             1.158k       117.908M/s
-bench_sha3::sha3_384/128            1012 ns         1012 ns       690020             2.296k       120.595M/s
-bench_sha3::sha3_384/256            1507 ns         1507 ns       464767             3.433k       162.047M/s
-bench_sha3::sha3_384/512            2472 ns         2472 ns       283207             5.653k       197.538M/s
-bench_sha3::sha3_384/1024           4927 ns         4927 ns       142239              11.3k       198.226M/s
-bench_sha3::sha3_384/2048           9807 ns         9806 ns        71394            22.524k        199.17M/s
-bench_sha3::sha3_384/4096          19624 ns        19624 ns        35677            45.109k       199.057M/s
-bench_sha3::sha3_512/32              513 ns          513 ns      1363676             1.152k       59.4614M/s
-bench_sha3::sha3_512/64              509 ns          509 ns      1374820             1.144k       119.831M/s
-bench_sha3::sha3_512/128            1001 ns         1001 ns       699436             2.274k       122.008M/s
-bench_sha3::sha3_512/256            1988 ns         1987 ns       352385             4.543k       122.845M/s
-bench_sha3::sha3_512/512            3941 ns         3941 ns       177803             9.036k       123.908M/s
-bench_sha3::sha3_512/1024           7359 ns         7359 ns        95078            16.899k         132.7M/s
-bench_sha3::sha3_512/2048          14179 ns        14179 ns        49332            32.584k       137.747M/s
-bench_sha3::sha3_512/4096          27844 ns        27843 ns        25099            64.013k       140.294M/s
-bench_sha3::shake128/32/32           708 ns          708 ns       988364             1.606k       86.2108M/s
-bench_sha3::shake128/32/64           900 ns          900 ns       778236             2.047k       101.766M/s
-bench_sha3::shake128/32/128         1281 ns         1281 ns       545164             2.925k       119.096M/s
-bench_sha3::shake128/64/32           709 ns          709 ns       987615             1.608k        129.16M/s
-bench_sha3::shake128/64/64           899 ns          899 ns       778721             2.046k       135.783M/s
-bench_sha3::shake128/64/128         1278 ns         1278 ns       547808             2.918k       143.271M/s
-bench_sha3::shake128/128/32          706 ns          706 ns       991560             1.602k       216.113M/s
-bench_sha3::shake128/128/64          896 ns          896 ns       781141              2.04k       204.276M/s
-bench_sha3::shake128/128/128        1278 ns         1278 ns       548169             2.917k       191.092M/s
-bench_sha3::shake128/256/32         1199 ns         1199 ns       584046             2.737k       229.008M/s
-bench_sha3::shake128/256/64         1386 ns         1386 ns       504875             3.167k       220.118M/s
-bench_sha3::shake128/256/128        1768 ns         1768 ns       396150             4.045k       207.134M/s
-bench_sha3::shake128/512/32         2190 ns         2190 ns       319939             5.015k       236.898M/s
-bench_sha3::shake128/512/64         2378 ns         2378 ns       294320             5.448k       230.975M/s
-bench_sha3::shake128/512/128        2758 ns         2757 ns       253717              6.32k       221.349M/s
-bench_sha3::shake128/1024/32        3660 ns         3659 ns       191306             8.395k       275.205M/s
-bench_sha3::shake128/1024/64        3851 ns         3851 ns       181728             8.835k       269.458M/s
-bench_sha3::shake128/1024/128       4232 ns         4232 ns       165367             9.712k       259.625M/s
-bench_sha3::shake128/2048/32        6596 ns         6596 ns       106260            15.148k       300.751M/s
-bench_sha3::shake128/2048/64        6786 ns         6786 ns       103065            15.586k       296.821M/s
-bench_sha3::shake128/2048/128       7170 ns         7170 ns        97689            16.469k       289.435M/s
-bench_sha3::shake128/4096/32       12486 ns        12486 ns        56027            28.698k       315.288M/s
-bench_sha3::shake128/4096/64       12684 ns        12683 ns        55229            29.151k       312.798M/s
-bench_sha3::shake128/4096/128      13067 ns        13066 ns        52763            30.031k         308.3M/s
-bench_sha3::shake256/32/32           705 ns          705 ns       994366             1.599k       86.6117M/s
-bench_sha3::shake256/32/64           895 ns          895 ns       782353             2.036k       102.309M/s
-bench_sha3::shake256/32/128         1276 ns         1276 ns       548923             2.912k       119.607M/s
-bench_sha3::shake256/64/32           705 ns          705 ns       994003               1.6k       129.865M/s
-bench_sha3::shake256/64/64           896 ns          896 ns       782167             2.038k       136.313M/s
-bench_sha3::shake256/64/128         1276 ns         1276 ns       548018             2.913k       143.493M/s
-bench_sha3::shake256/128/32          706 ns          706 ns       992663             1.601k       216.221M/s
-bench_sha3::shake256/128/64          894 ns          894 ns       782400             2.035k       204.827M/s
-bench_sha3::shake256/128/128        1274 ns         1274 ns       548811             2.908k       191.659M/s
-bench_sha3::shake256/256/32         1193 ns         1193 ns       586701             2.723k       230.157M/s
-bench_sha3::shake256/256/64         1386 ns         1386 ns       505510             3.165k       220.241M/s
-bench_sha3::shake256/256/128        1764 ns         1764 ns       396874             4.036k       207.585M/s
-bench_sha3::shake256/512/32         2179 ns         2179 ns       321214             4.989k       238.127M/s
-bench_sha3::shake256/512/64         2363 ns         2363 ns       296215             5.414k       232.431M/s
-bench_sha3::shake256/512/128        2752 ns         2752 ns       254621             6.308k       221.768M/s
-bench_sha3::shake256/1024/32        4138 ns         4138 ns       169193             9.496k       243.375M/s
-bench_sha3::shake256/1024/64        4329 ns         4329 ns       161754             9.935k       239.708M/s
-bench_sha3::shake256/1024/128       4707 ns         4707 ns       148728            10.805k       233.402M/s
-bench_sha3::shake256/2048/32        8038 ns         8037 ns        87040            18.463k       246.809M/s
-bench_sha3::shake256/2048/64        8227 ns         8227 ns        85045            18.899k       244.825M/s
-bench_sha3::shake256/2048/128       8607 ns         8606 ns        81401            19.773k       241.125M/s
-bench_sha3::shake256/4096/32       15412 ns        15412 ns        45424            35.425k       255.443M/s
-bench_sha3::shake256/4096/64       15605 ns        15605 ns        44860            35.872k       254.227M/s
-bench_sha3::shake256/4096/128      15990 ns        15990 ns        43768            36.756k       251.931M/s
+bench_sha3::keccakf1600              491 ns          491 ns      1425434             1.102k       388.536M/s
+bench_sha3::sha3_224/32              514 ns          514 ns      1357307             1.155k        59.358M/s
+bench_sha3::sha3_224/64              517 ns          517 ns      1355599             1.162k       117.999M/s
+bench_sha3::sha3_224/128             513 ns          513 ns      1364994             1.154k       237.765M/s
+bench_sha3::sha3_224/256            1004 ns         1004 ns       696816             2.281k        243.26M/s
+bench_sha3::sha3_224/512            1995 ns         1995 ns       350639              4.56k         244.8M/s
+bench_sha3::sha3_224/1024           3959 ns         3959 ns       176820             9.079k       246.655M/s
+bench_sha3::sha3_224/2048           7388 ns         7388 ns        94381            16.965k       264.356M/s
+bench_sha3::sha3_224/4096          14254 ns        14253 ns        49069            32.756k       274.067M/s
+bench_sha3::sha3_256/32              517 ns          517 ns      1363253             1.158k       59.0373M/s
+bench_sha3::sha3_256/64              515 ns          515 ns      1360303             1.154k       118.521M/s
+bench_sha3::sha3_256/128             514 ns          514 ns      1360903             1.152k       237.483M/s
+bench_sha3::sha3_256/256            1009 ns         1009 ns       694233              2.29k       242.007M/s
+bench_sha3::sha3_256/512            1996 ns         1996 ns       351147              4.56k       244.683M/s
+bench_sha3::sha3_256/1024           3951 ns         3951 ns       177147             9.056k       247.181M/s
+bench_sha3::sha3_256/2048           7877 ns         7877 ns        88819            18.087k       247.943M/s
+bench_sha3::sha3_256/4096          15239 ns        15239 ns        45910            35.023k       256.328M/s
+bench_sha3::sha3_384/32              515 ns          515 ns      1359433             1.152k       59.2735M/s
+bench_sha3::sha3_384/64              516 ns          516 ns      1358833             1.154k       118.381M/s
+bench_sha3::sha3_384/128            1012 ns         1012 ns       691169             2.297k       120.587M/s
+bench_sha3::sha3_384/256            1509 ns         1509 ns       464297             3.439k       161.793M/s
+bench_sha3::sha3_384/512            2480 ns         2480 ns       282337             5.674k       196.856M/s
+bench_sha3::sha3_384/1024           4932 ns         4932 ns       142078            11.311k       198.024M/s
+bench_sha3::sha3_384/2048           9836 ns         9836 ns        71263            22.591k       198.567M/s
+bench_sha3::sha3_384/4096          19634 ns        19634 ns        35654            45.132k       198.958M/s
+bench_sha3::sha3_512/32              513 ns          513 ns      1366094             1.152k       59.5197M/s
+bench_sha3::sha3_512/64              512 ns          512 ns      1371809             1.149k       119.301M/s
+bench_sha3::sha3_512/128            1006 ns         1005 ns       696759             2.285k       121.412M/s
+bench_sha3::sha3_512/256            1994 ns         1994 ns       350855             4.559k       122.428M/s
+bench_sha3::sha3_512/512            3952 ns         3952 ns       177033             9.063k       123.553M/s
+bench_sha3::sha3_512/1024           7375 ns         7375 ns        94999            16.935k       132.419M/s
+bench_sha3::sha3_512/2048          14229 ns        14228 ns        49178            32.698k       137.269M/s
+bench_sha3::sha3_512/4096          27934 ns        27934 ns        25057             64.22k       139.836M/s
+bench_sha3::shake128/32/32           710 ns          710 ns       988694             1.611k        85.987M/s
+bench_sha3::shake128/32/64           900 ns          900 ns       778795             2.048k       101.747M/s
+bench_sha3::shake128/32/128         1280 ns         1280 ns       546235             2.923k       119.183M/s
+bench_sha3::shake128/64/32           708 ns          708 ns       990747             1.607k       129.304M/s
+bench_sha3::shake128/64/64           898 ns          898 ns       779685             2.043k       135.952M/s
+bench_sha3::shake128/64/128         1283 ns         1283 ns       546024             2.928k       142.757M/s
+bench_sha3::shake128/128/32          708 ns          708 ns       989657             1.606k       215.609M/s
+bench_sha3::shake128/128/64          898 ns          898 ns       778971             2.043k       203.947M/s
+bench_sha3::shake128/128/128        1278 ns         1278 ns       545935             2.918k       190.999M/s
+bench_sha3::shake128/256/32         1202 ns         1202 ns       582985             2.742k         228.5M/s
+bench_sha3::shake128/256/64         1392 ns         1392 ns       502642             3.179k       219.275M/s
+bench_sha3::shake128/256/128        1772 ns         1772 ns       395130             4.055k       206.619M/s
+bench_sha3::shake128/512/32         2190 ns         2190 ns       319606             5.016k       236.858M/s
+bench_sha3::shake128/512/64         2381 ns         2381 ns       294106             5.454k       230.727M/s
+bench_sha3::shake128/512/128        2759 ns         2759 ns       253798             6.323k       221.253M/s
+bench_sha3::shake128/1024/32        3664 ns         3664 ns       190975             8.405k       274.874M/s
+bench_sha3::shake128/1024/64        3854 ns         3854 ns       181562             8.842k       269.223M/s
+bench_sha3::shake128/1024/128       4235 ns         4235 ns       165245             9.719k       259.408M/s
+bench_sha3::shake128/2048/32        6603 ns         6603 ns       106043            15.165k       300.414M/s
+bench_sha3::shake128/2048/64        6790 ns         6790 ns       103132            15.594k       296.653M/s
+bench_sha3::shake128/2048/128       7171 ns         7171 ns        97556            16.471k       289.405M/s
+bench_sha3::shake128/4096/32       12471 ns        12470 ns        56138             28.66k       315.696M/s
+bench_sha3::shake128/4096/64       12662 ns        12662 ns        55294            29.101k        313.31M/s
+bench_sha3::shake128/4096/128      13052 ns        13052 ns        53620            29.997k       308.633M/s
+bench_sha3::shake256/32/32           705 ns          705 ns       993390             1.599k       86.5983M/s
+bench_sha3::shake256/32/64           892 ns          892 ns       784921              2.03k       102.616M/s
+bench_sha3::shake256/32/128         1275 ns         1275 ns       548842             2.911k        119.67M/s
+bench_sha3::shake256/64/32           706 ns          706 ns       993132             1.602k       129.692M/s
+bench_sha3::shake256/64/64           900 ns          900 ns       781725             2.048k       135.656M/s
+bench_sha3::shake256/64/128         1276 ns         1276 ns       548214             2.914k       143.464M/s
+bench_sha3::shake256/128/32          706 ns          706 ns       991871             1.602k        216.15M/s
+bench_sha3::shake256/128/64          895 ns          895 ns       781711             2.038k       204.474M/s
+bench_sha3::shake256/128/128        1277 ns         1277 ns       550753             2.915k       191.177M/s
+bench_sha3::shake256/256/32         1194 ns         1194 ns       586212             2.724k       230.074M/s
+bench_sha3::shake256/256/64         1384 ns         1384 ns       505824             3.162k       220.478M/s
+bench_sha3::shake256/256/128        1766 ns         1766 ns       396955             4.039k       207.403M/s
+bench_sha3::shake256/512/32         2183 ns         2183 ns       320608             4.999k        237.63M/s
+bench_sha3::shake256/512/64         2369 ns         2369 ns       295536             5.428k       231.844M/s
+bench_sha3::shake256/512/128        2752 ns         2752 ns       254210             6.308k       221.783M/s
+bench_sha3::shake256/1024/32        4138 ns         4138 ns       169095             9.495k       243.383M/s
+bench_sha3::shake256/1024/64        4328 ns         4328 ns       161729             9.933k       239.726M/s
+bench_sha3::shake256/1024/128       4712 ns         4712 ns       148624            10.815k       233.172M/s
+bench_sha3::shake256/2048/32        8067 ns         8067 ns        86724            18.533k       245.882M/s
+bench_sha3::shake256/2048/64        8256 ns         8256 ns        84769            18.968k       243.956M/s
+bench_sha3::shake256/2048/128       8637 ns         8637 ns        81037            19.843k       240.262M/s
+bench_sha3::shake256/4096/32       15438 ns        15438 ns        45302            35.488k       255.002M/s
+bench_sha3::shake256/4096/64       15631 ns        15631 ns        44730            35.931k       253.816M/s
+bench_sha3::shake256/4096/128      16033 ns        16033 ns        43691            36.856k       251.253M/s
 ```
 
 ---

--- a/include/keccak.hpp
+++ b/include/keccak.hpp
@@ -3,7 +3,8 @@
 #include <cstddef>
 #include <cstdint>
 
-#if !defined __AVX2__
+#if defined __AVX2__
+#include <cstring>
 #include <immintrin.h>
 #endif
 
@@ -209,7 +210,9 @@ inline static void
 permute(uint64_t* const state)
 {
 
-#if !defined __AVX2__
+#if defined __AVX2__ && defined USE_AVX2
+
+#pragma message("Using AVX2 for keccak-[1600, 24] permutation")
 
   alignas(32) constexpr uint64_t bit_widths[]{ 64, 64, 64, 64 };
   const auto bw = _mm256_load_si256((__m256i*)bit_widths);

--- a/include/keccak.hpp
+++ b/include/keccak.hpp
@@ -3,6 +3,10 @@
 #include <cstddef>
 #include <cstdint>
 
+#if !defined __AVX2__
+#include <immintrin.h>
+#endif
+
 // Keccak-p[1600, 24] permutation
 namespace keccak {
 
@@ -22,14 +26,12 @@ constexpr size_t ROUNDS = 12 + 2 * L;
 //
 // Note, following offsets are obtained by performing % 64 ( bit width of lane )
 // on offsets provided in above mentioned link
-constexpr size_t ROT[]{ 0 % LANE_SIZE,   1 % LANE_SIZE,   190 % LANE_SIZE,
-                        28 % LANE_SIZE,  91 % LANE_SIZE,  36 % LANE_SIZE,
-                        300 % LANE_SIZE, 6 % LANE_SIZE,   55 % LANE_SIZE,
-                        276 % LANE_SIZE, 3 % LANE_SIZE,   10 % LANE_SIZE,
-                        171 % LANE_SIZE, 153 % LANE_SIZE, 231 % LANE_SIZE,
-                        105 % LANE_SIZE, 45 % LANE_SIZE,  15 % LANE_SIZE,
-                        21 % LANE_SIZE,  136 % LANE_SIZE, 210 % LANE_SIZE,
-                        66 % LANE_SIZE,  253 % LANE_SIZE, 120 % LANE_SIZE,
+constexpr size_t ROT[]{ 0 % LANE_SIZE,   1 % LANE_SIZE,   190 % LANE_SIZE, 28 % LANE_SIZE,
+                        91 % LANE_SIZE,  36 % LANE_SIZE,  300 % LANE_SIZE, 6 % LANE_SIZE,
+                        55 % LANE_SIZE,  276 % LANE_SIZE, 3 % LANE_SIZE,   10 % LANE_SIZE,
+                        171 % LANE_SIZE, 153 % LANE_SIZE, 231 % LANE_SIZE, 105 % LANE_SIZE,
+                        45 % LANE_SIZE,  15 % LANE_SIZE,  21 % LANE_SIZE,  136 % LANE_SIZE,
+                        210 % LANE_SIZE, 66 % LANE_SIZE,  253 % LANE_SIZE, 120 % LANE_SIZE,
                         78 % LANE_SIZE };
 
 // Computes single bit of Keccak-p[1600, 24] round constant ( at compile-time ),
@@ -93,14 +95,12 @@ compute_rc(const size_t r_idx)
 // Round constants to be XORed with lane (0, 0) of keccak-p[1600, 24]
 // permutation state, see section 3.2.5 of
 // https://dx.doi.org/10.s6028/NIST.FIPS.202
-constexpr uint64_t RC[ROUNDS]{ compute_rc(0),  compute_rc(1),  compute_rc(2),
-                               compute_rc(3),  compute_rc(4),  compute_rc(5),
-                               compute_rc(6),  compute_rc(7),  compute_rc(8),
-                               compute_rc(9),  compute_rc(10), compute_rc(11),
-                               compute_rc(12), compute_rc(13), compute_rc(14),
-                               compute_rc(15), compute_rc(16), compute_rc(17),
-                               compute_rc(18), compute_rc(19), compute_rc(20),
-                               compute_rc(21), compute_rc(22), compute_rc(23) };
+constexpr uint64_t RC[ROUNDS]{ compute_rc(0),  compute_rc(1),  compute_rc(2),  compute_rc(3),
+                               compute_rc(4),  compute_rc(5),  compute_rc(6),  compute_rc(7),
+                               compute_rc(8),  compute_rc(9),  compute_rc(10), compute_rc(11),
+                               compute_rc(12), compute_rc(13), compute_rc(14), compute_rc(15),
+                               compute_rc(16), compute_rc(17), compute_rc(18), compute_rc(19),
+                               compute_rc(20), compute_rc(21), compute_rc(22), compute_rc(23) };
 
 // Keccak-p[1600, 24] step mapping function θ, see section 3.2.1 of SHA3
 // specification https://dx.doi.org/10.6028/NIST.FIPS.202
@@ -211,9 +211,124 @@ round(uint64_t* const state, const size_t r_idx)
 inline static void
 permute(uint64_t* const state)
 {
+
+#if !defined __AVX2__
+
+  alignas(32) constexpr uint64_t bit_widths[]{ 64, 64, 64, 64 };
+  const auto bw = _mm256_load_si256((__m256i*)bit_widths);
+
+  alignas(32) uint64_t rot[28]{};
+  std::memcpy(rot, ROT, 25 * sizeof(uint64_t));
+
+  const auto shl0 = _mm256_loadu_si256((__m256i*)(rot + 0));
+  const auto shl4 = _mm256_loadu_si256((__m256i*)(rot + 4));
+  const auto shl5 = _mm256_loadu_si256((__m256i*)(rot + 5));
+  const auto shl9 = _mm256_loadu_si256((__m256i*)(rot + 9));
+  const auto shl10 = _mm256_loadu_si256((__m256i*)(rot + 10));
+  const auto shl14 = _mm256_loadu_si256((__m256i*)(rot + 14));
+  const auto shl15 = _mm256_loadu_si256((__m256i*)(rot + 15));
+  const auto shl19 = _mm256_loadu_si256((__m256i*)(rot + 19));
+  const auto shl20 = _mm256_loadu_si256((__m256i*)(rot + 20));
+  const auto shl24 = _mm256_loadu_si256((__m256i*)(rot + 24));
+
+  const auto shr0 = _mm256_sub_epi64(bw, shl0);
+  const auto shr4 = _mm256_sub_epi64(bw, shl4);
+  const auto shr5 = _mm256_sub_epi64(bw, shl5);
+  const auto shr9 = _mm256_sub_epi64(bw, shl9);
+  const auto shr10 = _mm256_sub_epi64(bw, shl10);
+  const auto shr14 = _mm256_sub_epi64(bw, shl14);
+  const auto shr15 = _mm256_sub_epi64(bw, shl15);
+  const auto shr19 = _mm256_sub_epi64(bw, shl19);
+  const auto shr20 = _mm256_sub_epi64(bw, shl20);
+  const auto shr24 = _mm256_sub_epi64(bw, shl24);
+
+  alignas(32) uint64_t tmp[28]{};
+  std::memcpy(tmp, state, 25 * sizeof(uint64_t));
+
+  auto s0 = _mm256_load_si256((__m256i*)(tmp + 0));
+  auto s4 = _mm256_load_si256((__m256i*)(tmp + 4));
+  auto s8 = _mm256_load_si256((__m256i*)(tmp + 8));
+  auto s12 = _mm256_load_si256((__m256i*)(tmp + 12));
+  auto s16 = _mm256_load_si256((__m256i*)(tmp + 16));
+  auto s20 = _mm256_load_si256((__m256i*)(tmp + 20));
+  auto s24 = _mm256_load_si256((__m256i*)(tmp + 24));
+
+  for (size_t i = 0; i < ROUNDS; i++) {
+    // θ step mapping
+
+    const auto t0 = _mm256_blend_epi32(s4, s8, 0b00000011u);
+    const auto s5 = _mm256_permute4x64_epi64(t0, 0b00111001);
+    const auto t1 = _mm256_blend_epi32(s8, s12, 0b00001111u);
+    const auto s10 = _mm256_permute4x64_epi64(t1, 0b01001110u);
+    const auto t2 = _mm256_blend_epi32(s12, s16, 0b00111111u);
+    const auto s15 = _mm256_permute4x64_epi64(t2, 0b10010011u);
+
+    const auto t3 = _mm256_xor_si256(s0, s5);
+    const auto t4 = _mm256_xor_si256(t3, s10);
+    const auto t5 = _mm256_xor_si256(t4, s15);
+    const auto c0_4 = _mm256_xor_si256(t5, s20); // c[0], c[1], c[2], c[3]
+
+    const auto s19 = _mm256_permute4x64_epi64(s16, 0b10010011u); // s[19], s[16], s[17], s[18]
+    const auto s14 = _mm256_permute4x64_epi64(s12, 0b11010010u); // s[14], s[12], s[13], s[15]
+    const auto s9 = _mm256_permute4x64_epi64(s8, 0b11100001u);   // s[9], s[8], s[10], s[11]
+
+    const auto t6 = _mm256_xor_si256(s4, s9);
+    const auto t7 = _mm256_xor_si256(t6, s14);
+    const auto t8 = _mm256_xor_si256(t7, s19);
+    const auto c4 = _mm256_xor_si256(t8, s24); // c[4], _, _, _
+
+    const auto t9 = _mm256_slli_epi64(c0_4, 1);
+    const auto t10 = _mm256_srli_epi64(c0_4, 63);
+    const auto c0_4_ = _mm256_xor_si256(t9, t10); // c'[0], c'[1], c'[2], c'[3]
+
+    const auto t11 = _mm256_slli_epi64(c4, 1);
+    const auto t12 = _mm256_srli_epi64(c4, 63);
+    const auto c4_ = _mm256_xor_si256(t11, t12); // c'[4], _, _, _
+
+    const auto t13 = _mm256_permute4x64_epi64(c4_, 0b11100001u); // _, c'[4], _, _
+    const auto t14 = _mm256_blend_epi32(c0_4_, t13, 0b00001100u);
+    const auto t15 = _mm256_permute4x64_epi64(t14, 0b00011110u);
+
+    const auto d1_5 = _mm256_xor_si256(c0_4, t15); // d[1], d[2], d[3], d[4]
+
+    const auto t16 = _mm256_permute4x64_epi64(c0_4_, 0b00111001u); // c'[1], c'[2], c'[3], c'[0]
+    const auto d0 = _mm256_xor_si256(c4, t16);                     // d[0], _, _, _
+
+    const auto t17 = _mm256_permute4x64_epi64(d0, 0b00111001u);   // _, _, _, d[0]
+    const auto t18 = _mm256_blend_epi32(t17, d1_5, 0b00111111u);  // d[1], d[2], d[3], d[0]
+    const auto d0_4 = _mm256_permute4x64_epi64(t18, 0b10010011u); // d[0], d[1], d[2], d[3]
+
+    const auto s0_ = _mm256_xor_si256(s0, d0_4);   // s'[0], s'[1], s'[2], s'[3]
+    const auto s5_ = _mm256_xor_si256(s5, d0_4);   // s'[5], s'[6], s'[7], s'[8]
+    const auto s10_ = _mm256_xor_si256(s10, d0_4); // s'[10], s'[11], s'[12], s'[13]
+    const auto s15_ = _mm256_xor_si256(s15, d0_4); // s'[15], s'[16], s'[17], s'[18]
+    const auto s20_ = _mm256_xor_si256(s20, d0_4); // s'[20], s'[21], s'[22], s'[23]
+
+    const auto d4 = _mm256_permute4x64_epi64(d1_5, 0b10010011u); // d[4], d[1], d[2], d[3]
+    const auto s4_ = _mm256_xor_si256(s4, d4);                   // s'[4], _, _, _
+    const auto s9_ = _mm256_xor_si256(s9, d4);                   // s'[9], _, _, _
+    const auto s14_ = _mm256_xor_si256(s14, d4);                 // s'[14], _, _, _
+    const auto s19_ = _mm256_xor_si256(s19, d4);                 // s'[19], _, _, _
+    const auto s24_ = _mm256_xor_si256(s24, d4);                 // s'[24], _, _, _
+  }
+
+  _mm256_store_si256((__m256i*)(tmp + 0), s0);
+  _mm256_store_si256((__m256i*)(tmp + 4), s4);
+  _mm256_store_si256((__m256i*)(tmp + 8), s8);
+  _mm256_store_si256((__m256i*)(tmp + 12), s12);
+  _mm256_store_si256((__m256i*)(tmp + 16), s16);
+  _mm256_store_si256((__m256i*)(tmp + 20), s20);
+  _mm256_store_si256((__m256i*)(tmp + 24), s24);
+
+  std::memcpy(state, tmp, 25 * sizeof(uint64_t));
+
+#else
+
   for (size_t i = 0; i < ROUNDS; i++) {
     round(state, i);
   }
+
+#endif
 }
 
 }

--- a/include/keccak.hpp
+++ b/include/keccak.hpp
@@ -220,16 +220,16 @@ permute(uint64_t* const state)
   alignas(32) uint64_t rot[28]{};
   std::memcpy(rot, ROT, 25 * sizeof(uint64_t));
 
-  const auto shl0 = _mm256_loadu_si256((__m256i*)(rot + 0));
-  const auto shl4 = _mm256_loadu_si256((__m256i*)(rot + 4));
+  const auto shl0 = _mm256_load_si256((__m256i*)(rot + 0));
+  const auto shl4 = _mm256_load_si256((__m256i*)(rot + 4));
   const auto shl5 = _mm256_loadu_si256((__m256i*)(rot + 5));
   const auto shl9 = _mm256_loadu_si256((__m256i*)(rot + 9));
   const auto shl10 = _mm256_loadu_si256((__m256i*)(rot + 10));
   const auto shl14 = _mm256_loadu_si256((__m256i*)(rot + 14));
   const auto shl15 = _mm256_loadu_si256((__m256i*)(rot + 15));
   const auto shl19 = _mm256_loadu_si256((__m256i*)(rot + 19));
-  const auto shl20 = _mm256_loadu_si256((__m256i*)(rot + 20));
-  const auto shl24 = _mm256_loadu_si256((__m256i*)(rot + 24));
+  const auto shl20 = _mm256_load_si256((__m256i*)(rot + 20));
+  const auto shl24 = _mm256_load_si256((__m256i*)(rot + 24));
 
   const auto shr0 = _mm256_sub_epi64(bw, shl0);
   const auto shr4 = _mm256_sub_epi64(bw, shl4);
@@ -310,6 +310,40 @@ permute(uint64_t* const state)
     const auto s14_ = _mm256_xor_si256(s14, d4);                 // s'[14], _, _, _
     const auto s19_ = _mm256_xor_si256(s19, d4);                 // s'[19], _, _, _
     const auto s24_ = _mm256_xor_si256(s24, d4);                 // s'[24], _, _, _
+
+    // ρ step mapping
+
+    const auto t19 = _mm256_sllv_epi64(s0_, shl0);
+    const auto t20 = _mm256_srlv_epi64(s0_, shr0);
+    const auto s0__ = _mm256_xor_si256(t19, t20); // s'[0], s'[1], s'[2], s'[3]
+    const auto t21 = _mm256_sllv_epi64(s5_, shl5);
+    const auto t22 = _mm256_srlv_epi64(s5_, shr5);
+    const auto s5__ = _mm256_xor_si256(t21, t22); // s'[5], s'[6], s'[7], s'[8]
+    const auto t23 = _mm256_sllv_epi64(s10_, shl10);
+    const auto t24 = _mm256_srlv_epi64(s10_, shr10);
+    const auto s10__ = _mm256_xor_si256(t23, t24); // s'[10], s'[11], s'[12], s'[13]
+    const auto t25 = _mm256_sllv_epi64(s15_, shl15);
+    const auto t26 = _mm256_srlv_epi64(s15_, shr15);
+    const auto s15__ = _mm256_xor_si256(t25, t26); // s'[15], s'[16], s'[17], s'[18]
+    const auto t27 = _mm256_sllv_epi64(s20_, shl20);
+    const auto t28 = _mm256_srlv_epi64(s20_, shr20);
+    const auto s20__ = _mm256_xor_si256(t27, t28); // s'[20], s'[21], s'[22], s'[23]
+
+    const auto t29 = _mm256_sllv_epi64(s4_, shl4);
+    const auto t30 = _mm256_srlv_epi64(s4_, shr4);
+    const auto s4__ = _mm256_xor_si256(t29, t30); // s'[4], _, _, _
+    const auto t31 = _mm256_sllv_epi64(s9_, shl9);
+    const auto t32 = _mm256_srlv_epi64(s9_, shr9);
+    const auto s9__ = _mm256_xor_si256(t31, t32); // s'[9], _, _, _
+    const auto t33 = _mm256_sllv_epi64(s14_, shl14);
+    const auto t34 = _mm256_srlv_epi64(s14_, shr14);
+    const auto s14__ = _mm256_xor_si256(t33, t34); // s'[14], _, _, _
+    const auto t35 = _mm256_sllv_epi64(s19_, shl19);
+    const auto t36 = _mm256_srlv_epi64(s19_, shr19);
+    const auto s19__ = _mm256_xor_si256(t35, t36); // s'[19], _, _, _
+    const auto t37 = _mm256_sllv_epi64(s24_, shl24);
+    const auto t38 = _mm256_srlv_epi64(s24_, shr24);
+    const auto s24__ = _mm256_xor_si256(t37, t38); // s'[24], _, _, _
   }
 
   _mm256_store_si256((__m256i*)(tmp + 0), s0);

--- a/include/keccak.hpp
+++ b/include/keccak.hpp
@@ -34,22 +34,18 @@ constexpr size_t ROT[]{ 0 % LANE_SIZE,   1 % LANE_SIZE,   190 % LANE_SIZE, 28 % 
                         105 % LANE_SIZE, 45 % LANE_SIZE,  15 % LANE_SIZE,  21 % LANE_SIZE,  136 % LANE_SIZE,
                         210 % LANE_SIZE, 66 % LANE_SIZE,  253 % LANE_SIZE, 120 % LANE_SIZE, 78 % LANE_SIZE };
 
-// Precomputed table holding (destination, source) index pairs of π step mapping function, used for permuting
-// kecack-p[1600, 24] state array s.t. destination state array's `idx_first` lane will get value from
-// source state array's `idx_second` lane.
+// Precomputed table used for looking up source index during application of π step mapping function on
+// keccak-[1600, 24] state
 //
-// print('idx_first <= idx_second')
+// print('to <= from')
 // for y in range(5):
-//    for x in range(x):
+//    for x in range(5):
 //        print(f'{y * 5 + x} <= {x * 5 + (x + 3 * y) % 5}')
 //
 // Table generated using above Python code snippet. See section 3.2.3 of the specification
 // https://dx.doi.org/10.6028/NIST.FIPS.202
-constexpr std::pair<size_t, size_t> PERM[]{ { 0, 0 },  { 1, 6 },  { 2, 12 },  { 18, 3 },  { 24, 4 },
-                                            { 3, 5 },  { 9, 6 },  { 10, 7 },  { 8, 16 },  { 9, 22 },
-                                            { 1, 10 }, { 11, 7 }, { 12, 13 }, { 19, 13 }, { 20, 14 },
-                                            { 4, 15 }, { 16, 5 }, { 17, 11 }, { 17, 18 }, { 19, 23 },
-                                            { 2, 20 }, { 8, 21 }, { 22, 14 }, { 15, 23 }, { 24, 21 } };
+constexpr size_t PERM[]{ 0,  6,  12, 18, 24, 3,  9,  10, 16, 22, 1,  7, 13,
+                         19, 20, 4,  5,  11, 17, 23, 2,  8,  14, 15, 21 };
 
 // Computes single bit of Keccak-p[1600, 24] round constant ( at compile-time ),
 // using binary LFSR, defined by primitive polynomial x^8 + x^6 + x^5 + x^4 + 1
@@ -206,8 +202,7 @@ pi(const uint64_t* const __restrict istate, // input permutation state
 #pragma unroll 25
 #endif
   for (size_t i = 0; i < 25; i++) {
-    const auto tmp = PERM[i];
-    ostate[tmp.first] = istate[tmp.second];
+    ostate[i] = istate[PERM[i]];
   }
 }
 

--- a/include/keccak.hpp
+++ b/include/keccak.hpp
@@ -366,6 +366,55 @@ permute(uint64_t* const state)
     const auto t53 = s14__;                                        // s''[22], _, _, _
     const auto t54 = s15__;                                        // s''[23], _, _, _
     const auto t55 = _mm256_permute4x64_epi64(s20__, 0b01010101u); // s''[24], _, _, _
+
+    // χ step mapping
+
+    const auto t56 = _mm256_andnot_si256(t44, t45);
+    const auto t57 = _mm256_xor_si256(t41, t56); // s'''[0], s'''[5], s'''[10], s'''[15]
+
+    const auto t58 = _mm256_andnot_si256(t45, t47);
+    const auto t59 = _mm256_xor_si256(t44, t58); // s'''[1], s'''[6], s'''[11], s'''[16]
+
+    const auto t60 = _mm256_andnot_si256(t47, t50);
+    const auto t61 = _mm256_xor_si256(t45, t60); // s'''[2], s'''[7], s'''[12], s'''[17]
+
+    const auto t62 = _mm256_andnot_si256(t50, t41);
+    const auto t63 = _mm256_xor_si256(t47, t62); // s'''[3], s'''[8], s'''[13], s'''[18]
+
+    const auto t64 = _mm256_andnot_si256(t41, t44);
+    const auto t65 = _mm256_xor_si256(t50, t64); // s'''[4], s'''[9], s'''[14], s'''[19]
+
+    const auto t66 = _mm256_xor_si256(t51, _mm256_andnot_si256(t52, t53)); // s'''[20], _, _, _
+    const auto t67 = _mm256_xor_si256(t52, _mm256_andnot_si256(t53, t54)); // s'''[21], _, _, _
+    const auto t68 = _mm256_xor_si256(t53, _mm256_andnot_si256(t54, t55)); // s'''[22], _, _, _
+    const auto t69 = _mm256_xor_si256(t54, _mm256_andnot_si256(t55, t51)); // s'''[23], _, _, _
+    const auto t70 = _mm256_xor_si256(t55, _mm256_andnot_si256(t51, t52)); // s'''[24], _, _, _
+
+    const auto t71 = _mm256_permute4x64_epi64(t59, 0b10010011u); // s'''[16], s'''[1], s'''[6], s'''[11]
+    const auto t72 = _mm256_permute4x64_epi64(t61, 0b01001110u); // s'''[12], s'''[17], s'''[2], s'''[7]
+    const auto t73 = _mm256_permute4x64_epi64(t63, 0b00111001u); // s'''[8], s'''[13], s'''[18], s'''[3]
+
+    const auto t74 = _mm256_blend_epi32(t57, t71, 0b11001100u); // s'''[0], s'''[1], s'''[10], s'''[11]
+    const auto t75 = _mm256_blend_epi32(t72, t73, 0b11001100u); // s'''[12], s'''[13], s'''[2], s'''[3]
+    s0 = _mm256_blend_epi32(t74, t75, 0b11110000u);             // s'''[0], s'''[1], s'''[2], s'''[3]
+
+    const auto t76 = _mm256_blend_epi32(t65, t57, 0b11001100u); // s'''[4], s'''[5], s'''[14], s'''[15]
+    const auto t77 = _mm256_blend_epi32(t71, t72, 0b11001100u); // s'''[16], s'''[17], s'''[6], s'''[7]
+    s4 = _mm256_blend_epi32(t76, t77, 0b11110000u);             // s'''[4], s'''[5], s'''[6], s'''[7]
+
+    const auto t78 = _mm256_blend_epi32(t65, t73, 0b00110011u); // s'''[8], s'''[9], s'''[18], s'''[19]
+    s8 = _mm256_blend_epi32(t78, t74, 0b11110000u);             // s'''[8], s'''[9], s'''[10], s'''[11]
+
+    s12 = _mm256_blend_epi32(t75, t76, 0b11110000u); // s'''[12], s'''[13], s'''[14], s'''[15]
+    s16 = _mm256_blend_epi32(t77, t78, 0b11110000u); // s'''[16], s'''[17], s'''[18], s'''[19]
+
+    const auto t79 = _mm256_permute4x64_epi64(t67, 0b11100001u); // _, s'''[21], _, _
+    const auto t80 = _mm256_permute4x64_epi64(t68, 0b11001001u); // _, _, s'''[22], _
+    const auto t81 = _mm256_permute4x64_epi64(t69, 0b00111001u); // _, _, _, s'''[23]
+    const auto t82 = _mm256_blend_epi32(t66, t79, 0b00001100u);
+    const auto t83 = _mm256_blend_epi32(t82, t80, 0b00110000u);
+    s20 = _mm256_blend_epi32(t83, t81, 0b11000000u); // s'''[20], s'''[21], s'''[22], s'''[23]
+    s24 = t70;                                       // s'''[24], _, _, _
   }
 
   _mm256_store_si256((__m256i*)(tmp + 0), s0);

--- a/include/keccak.hpp
+++ b/include/keccak.hpp
@@ -4,7 +4,7 @@
 #include <cstdint>
 #include <utility>
 
-#if defined __AVX2__
+#if defined __AVX2__ && USE_AVX2 != 0
 #include <cstring>
 #include <immintrin.h>
 #endif
@@ -105,7 +105,7 @@ compute_rc(const size_t r_idx)
   return tmp;
 }
 
-#if defined __AVX2__ && defined USE_AVX2
+#if defined __AVX2__ && USE_AVX2 != 0
 
 // Round constants to be XORed with lane (0, 0) of keccak-p[1600, 24]
 // permutation state, when using AVX2 implementation, see section 3.2.5 of
@@ -257,7 +257,7 @@ inline static void
 permute(uint64_t* const state)
 {
 
-#if defined __AVX2__ && defined USE_AVX2
+#if defined __AVX2__ && USE_AVX2 != 0
 
 #pragma message("Using AVX2 for keccak-[1600, 24] permutation")
 

--- a/include/keccak.hpp
+++ b/include/keccak.hpp
@@ -165,6 +165,11 @@ theta(uint64_t* const state)
 inline static void
 rho(uint64_t* const state)
 {
+#if defined __GNUC__
+#pragma GCC unroll 25
+#elif defined __clang__
+#pragma unroll 25
+#endif
   for (size_t i = 0; i < 25; i++) {
     state[i] = std::rotl(state[i], ROT[i]);
   }

--- a/include/sha3_224.hpp
+++ b/include/sha3_224.hpp
@@ -10,9 +10,7 @@ namespace sha3_224 {
 // See SHA3 hash function definition in section 6.1 of SHA3 specification
 // https://dx.doi.org/10.6028/NIST.FIPS.202
 static void
-hash(const uint8_t* const __restrict msg,
-     const size_t mlen,
-     uint8_t* const __restrict dig)
+hash(const uint8_t* const __restrict msg, const size_t mlen, uint8_t* const __restrict dig)
 {
   constexpr size_t dlen = 224;
   constexpr size_t capacity = 2 * dlen;

--- a/include/sha3_256.hpp
+++ b/include/sha3_256.hpp
@@ -10,9 +10,7 @@ namespace sha3_256 {
 // See SHA3 hash function definition in section 6.1 of SHA3 specification
 // https://dx.doi.org/10.6028/NIST.FIPS.202
 static void
-hash(const uint8_t* const __restrict msg,
-     const size_t mlen,
-     uint8_t* const __restrict dig)
+hash(const uint8_t* const __restrict msg, const size_t mlen, uint8_t* const __restrict dig)
 {
   constexpr size_t dlen = 256;
   constexpr size_t capacity = 2 * dlen;

--- a/include/sha3_384.hpp
+++ b/include/sha3_384.hpp
@@ -10,9 +10,7 @@ namespace sha3_384 {
 // See SHA3 hash function definition in section 6.1 of SHA3 specification
 // https://dx.doi.org/10.6028/NIST.FIPS.202
 static void
-hash(const uint8_t* const __restrict msg,
-     const size_t mlen,
-     uint8_t* const __restrict dig)
+hash(const uint8_t* const __restrict msg, const size_t mlen, uint8_t* const __restrict dig)
 {
   constexpr size_t dlen = 384;
   constexpr size_t capacity = 2 * dlen;

--- a/include/sha3_512.hpp
+++ b/include/sha3_512.hpp
@@ -10,9 +10,7 @@ namespace sha3_512 {
 // See SHA3 hash function definition in section 6.1 of SHA3 specification
 // https://dx.doi.org/10.6028/NIST.FIPS.202
 static void
-hash(const uint8_t* const __restrict msg,
-     const size_t mlen,
-     uint8_t* const __restrict dig)
+hash(const uint8_t* const __restrict msg, const size_t mlen, uint8_t* const __restrict dig)
 {
   constexpr size_t dlen = 512;
   constexpr size_t capacity = 2 * dlen;

--- a/include/sponge.hpp
+++ b/include/sponge.hpp
@@ -56,14 +56,13 @@ pad101(const size_t mlen, uint8_t* const pad)
 // This function helps when absorbing padded message bytes into sponge.
 template<const uint8_t dom_sep, const size_t bits, const size_t rate>
 static void
-get_msg_blk(
-  const uint8_t* const __restrict msg, // message ( except domain seperator )
-  const size_t mlen,                   // in bytes
-  const uint8_t* const __restrict pad, // padding ( includes domain seperator )
-  const size_t plen,                   // in bits
-  uint8_t* const __restrict blk,       // extracted block
-  const size_t blk_idx                 // index of block to extract
-  )
+get_msg_blk(const uint8_t* const __restrict msg, // message ( except domain seperator )
+            const size_t mlen,                   // in bytes
+            const uint8_t* const __restrict pad, // padding ( includes domain seperator )
+            const size_t plen,                   // in bits
+            uint8_t* const __restrict blk,       // extracted block
+            const size_t blk_idx                 // index of block to extract
+            )
   requires(check_domain_seperator(bits))
 {
   const size_t mblen = mlen << 3;             // in bits | < first segment >
@@ -100,9 +99,7 @@ get_msg_blk(
 // https://dx.doi.org/10.6028/NIST.FIPS.202
 template<const uint8_t dom_sep, const size_t bits, const size_t rate>
 static void
-absorb(uint64_t* const __restrict state,
-       const uint8_t* const __restrict msg,
-       const size_t mlen)
+absorb(uint64_t* const __restrict state, const uint8_t* const __restrict msg, const size_t mlen)
   requires(check_domain_seperator(bits))
 {
   const size_t mblen = mlen << 3;        // in bits
@@ -154,9 +151,7 @@ absorb(uint64_t* const __restrict state,
 // https://dx.doi.org/10.6028/NIST.FIPS.202
 template<const size_t rate>
 static void
-squeeze(uint64_t* const __restrict state,
-        uint8_t* const __restrict dig,
-        const size_t dlen)
+squeeze(uint64_t* const __restrict state, uint8_t* const __restrict dig, const size_t dlen)
 {
   constexpr size_t rbytes = rate >> 3;
 

--- a/wrapper/sha3.cpp
+++ b/wrapper/sha3.cpp
@@ -51,10 +51,9 @@ extern "C"
 
   // Given N (>=0) -bytes input message, this routines computes 28 -bytes output
   // digest, using SHA3-224 hashing algorithm
-  void sha3_224_hash(
-    const uint8_t* const __restrict in, // input message
-    const size_t ilen,                  // len(in) | >= 0
-    uint8_t* const __restrict out       // 28 -bytes digest, to be computed
+  void sha3_224_hash(const uint8_t* const __restrict in, // input message
+                     const size_t ilen,                  // len(in) | >= 0
+                     uint8_t* const __restrict out       // 28 -bytes digest, to be computed
   )
   {
     sha3_224::hash(in, ilen, out);
@@ -62,10 +61,9 @@ extern "C"
 
   // Given N (>=0) -bytes input message, this routines computes 32 -bytes output
   // digest, using SHA3-256 hashing algorithm
-  void sha3_256_hash(
-    const uint8_t* const __restrict in, // input message
-    const size_t ilen,                  // len(in) | >= 0
-    uint8_t* const __restrict out       // 32 -bytes digest, to be computed
+  void sha3_256_hash(const uint8_t* const __restrict in, // input message
+                     const size_t ilen,                  // len(in) | >= 0
+                     uint8_t* const __restrict out       // 32 -bytes digest, to be computed
   )
   {
     sha3_256::hash(in, ilen, out);
@@ -73,10 +71,9 @@ extern "C"
 
   // Given N (>=0) -bytes input message, this routines computes 48 -bytes output
   // digest, using SHA3-384 hashing algorithm
-  void sha3_384_hash(
-    const uint8_t* const __restrict in, // input message
-    const size_t ilen,                  // len(in) | >= 0
-    uint8_t* const __restrict out       // 48 -bytes digest, to be computed
+  void sha3_384_hash(const uint8_t* const __restrict in, // input message
+                     const size_t ilen,                  // len(in) | >= 0
+                     uint8_t* const __restrict out       // 48 -bytes digest, to be computed
   )
   {
     sha3_384::hash(in, ilen, out);
@@ -84,10 +81,9 @@ extern "C"
 
   // Given N (>=0) -bytes input message, this routines computes 64 -bytes output
   // digest, using SHA3-512 hashing algorithm
-  void sha3_512_hash(
-    const uint8_t* const __restrict in, // input message
-    const size_t ilen,                  // len(in) | >= 0
-    uint8_t* const __restrict out       // 64 -bytes digest, to be computed
+  void sha3_512_hash(const uint8_t* const __restrict in, // input message
+                     const size_t ilen,                  // len(in) | >= 0
+                     uint8_t* const __restrict out       // 64 -bytes digest, to be computed
   )
   {
     sha3_512::hash(in, ilen, out);


### PR DESCRIPTION
Added optional compilation using AVX2 intrinsics on platforms supporting AVX2. 

> **Note**
Define `USE_AVX2` flag at compile-time.

## On Intel(R) Core(TM) i5-8279U CPU @ 2.40GHz

When issued `make benchmark`

### Without AVX2

```bash
2022-12-05T10:06:19+04:00
Running ./bench/a.out
Run on (8 X 2400 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB
  L1 Instruction 32 KiB
  L2 Unified 256 KiB (x4)
  L3 Unified 6144 KiB
Load Average: 1.67, 1.80, 2.01
------------------------------------------------------------------------------------------------------------
Benchmark                              Time             CPU   Iterations average_cpu_cycles bytes_per_second
------------------------------------------------------------------------------------------------------------
bench_sha3::keccakf1600              354 ns          354 ns      2000177                831       538.831M/s
```

### With AVX2

```bash
2022-12-05T10:07:16+04:00
Running ./bench/a.out
Run on (8 X 2400 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB
  L1 Instruction 32 KiB
  L2 Unified 256 KiB (x4)
  L3 Unified 6144 KiB
Load Average: 2.03, 1.88, 2.02
------------------------------------------------------------------------------------------------------------
Benchmark                              Time             CPU   Iterations average_cpu_cycles bytes_per_second
------------------------------------------------------------------------------------------------------------
bench_sha3::keccakf1600              387 ns          386 ns      1837714                911       493.699M/s
```

Looks like AVX2 is not helping much here !