### PR TITLE
Make Everything `constexpr`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ benchmarks/bench.out: benchmarks/main.cpp include/*.hpp include/benchmarks/*.hpp
 	$(CXX) $(CXX_FLAGS) $(WARN_FLAGS) $(OPT_FLAGS) $(I_FLAGS) $< -lbenchmark -lpthread -o $@
 
 benchmark: benchmarks/bench.out
-	./$< --benchmark_counters_tabular=true
+	./$< --benchmark_counters_tabular=true --benchmark_min_warmup_time=.1
 
 benchmarks/perf.out: benchmarks/main.cpp include/*.hpp include/benchmarks/*.hpp
 	# In case you've built google-benchmark with libPFM support.
@@ -52,4 +52,4 @@ benchmarks/perf.out: benchmarks/main.cpp include/*.hpp include/benchmarks/*.hpp
 						-DCYCLES_PER_BYTE -DINSTRUCTIONS_PER_CYCLE $< -lbenchmark -lpthread -lpfm -o $@
 
 perf: benchmarks/perf.out
-	./$< --benchmark_counters_tabular=true --benchmark_perf_counters=CYCLES,INSTRUCTIONS
+	./$< --benchmark_counters_tabular=true --benchmark_min_warmup_time=.1 --benchmark_perf_counters=CYCLES,INSTRUCTIONS

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # sha3
-SHA3: Permutation-Based Hash and Extendable-Output Functions.
+`constexpr` ( i.e. **Compile-time Evaluable** ) SHA3: Permutation-Based Hash and Extendable-Output Functions.
 
 ## Overview
 
 SHA3 standard by NIST ( i.e. NIST FIPS PUB 202 ) specifies four ( of different digest length ) permutation-based hash functions and two extendable-output functions, which are built on top of keccak-p[1600, 24] permutation.
 
-These hash functions and extendable output functions are pretty commonly used in various post-quantum cryptography algorithms ( those used for public key encryption, key establishment mechanism & digital signature ), some of which are already declared as selected candidates ( e.g. Kyber, Falcon, Dilithium, SPHINCS+ etc. ) of NIST PQC standardization effort - waiting to be standardized or some are still competing ( e.g. Bike, Classic McEliece etc. ) in final round of standardization. I decided to implement SHA3 specification as a **header-only C++ library**, so that I can make use of it as a modular dependency ( say pinned to specific commit using git submodule ) in libraries where I implement various PQC schemes.
+These hash functions and extendable output functions are pretty commonly used in various post-quantum cryptography algorithms ( those used for public key encryption, key establishment mechanism & digital signature ), some of which are already declared as selected candidates ( e.g. Kyber, Falcon, Dilithium, SPHINCS+ etc. ) of NIST PQC standardization effort - waiting to be standardized or some are still competing. I decided to implement SHA3 specification as a **header-only C++ library**, so that I can make use of it as a modular dependency ( say pinned to specific commit using git submodule ) in libraries where I implement various PQC schemes.
 
 Few of those places, where I've already used `sha3` as ( git submodule based ) dependency
 
@@ -14,19 +14,24 @@ Few of those places, where I've already used `sha3` as ( git submodule based ) d
 - [SPHINCS+: Stateless Hash-based Digital Signature Algorithm](https://github.com/itzmeanjan/sphincs)
 - [Falcon: Fast-Fourier Lattice-based Compact Signatures over NTRU](https://github.com/itzmeanjan/falcon)
 - [FrodoKEM: Practical Quantum-secure Key Encapsulation from Generic Lattices](https://github.com/itzmeanjan/frodokem)
+- [Saber: Post-Quantum Key Encapsulation Mechanism](https://github.com/itzmeanjan/saber)
 
 > **Warning** Above list may not be up-to-date !
 
-Here I'm maintaining a zero-dependency, header-only C++ library, using modern C++ features ( such as C++{>=11} ), which is fairly easy-to-use in your project, implementing SHA3 [specification](https://dx.doi.org/10.6028/NIST.FIPS.202) i.e. NIST FIPS PUB 202. Following algorithms ( with flexible interfaces ) are implemented in `sha3` library.
+Here I'm maintaining a zero-dependency, header-only C++ library, using modern C++ features ( such as C++{>=11} ), which is fairly easy-to-use in your project, implementing SHA3 [specification](https://dx.doi.org/10.6028/NIST.FIPS.202) i.e. NIST FIPS PUB 202. 
+
+> **Note** All Sha3 hash functions and xofs are implemented as `constexpr` functions - meaning for any statically defined input message these functions can be evaluated in compile-time in constant-expression context. See [tests](./tests).
+
+Following algorithms ( with flexible interfaces ) are implemented in `sha3` library.
 
 Algorithm | Input | Output | Behaviour | Namespace + Header
 --- | :-: | :-: | :-: | --:
-SHA3-224 | N ( >=0 ) -bytes message | 28 -bytes digest | Given N -bytes input message, this routine computes 28 -bytes sha3-224 digest, while *(incrementally)* consuming message into Keccak[448] sponge. | [`sha3_224::sha3_224`](./include/sha3_224.hpp)
-SHA3-256 | N ( >=0 ) -bytes message | 32 -bytes digest | Given N -bytes input message, this routine computes 32 -bytes sha3-256 digest, while *(incrementally)* consuming message into Keccak[512] sponge. | [`sha3_256::sha3_256`](./include/sha3_256.hpp)
-SHA3-384 | N ( >=0 ) -bytes message | 48 -bytes digest | Given N -bytes input message, this routine computes 48 -bytes sha3-384 digest, while *(incrementally)* consuming message into Keccak[768] sponge. | [`sha3_384::sha3_384`](./include/sha3_384.hpp)
-SHA3-512 | N ( >=0 ) -bytes message | 64 -bytes digest | Given N -bytes input message, this routine computes 64 -bytes sha3-512 digest, while *(incrementally)* consuming message into Keccak[1024] sponge. | [`sha3_512::sha3_512`](./include/sha3_512.hpp)
-SHAKE-128 | N ( >=0 ) -bytes message | M ( >=0 ) -bytes output | Given N -bytes input message, this routine squeezes arbitrary ( = M ) number of output bytes from Keccak[256] sponge, which has already *(incrementally)* absorbed input bytes. | [`shake128::shake128`](./include/shake128.hpp)
-SHAKE-256 | N ( >=0 ) -bytes message | M ( >=0 ) -bytes digest | Given N -bytes input message, this routine squeezes arbitrary ( = M ) number of output bytes from Keccak[512] sponge, which has already *(incrementally)* absorbed input bytes. | [`shake256::shake256`](./include/shake256.hpp)
+SHA3-224 | N ( >=0 ) -bytes message | 28 -bytes digest | Given N -bytes input message, this routine computes 28 -bytes sha3-224 digest, while *(incrementally)* consuming message into Keccak[448] sponge. | [`sha3_224::sha3_224_t`](./include/sha3_224.hpp)
+SHA3-256 | N ( >=0 ) -bytes message | 32 -bytes digest | Given N -bytes input message, this routine computes 32 -bytes sha3-256 digest, while *(incrementally)* consuming message into Keccak[512] sponge. | [`sha3_256::sha3_256_t`](./include/sha3_256.hpp)
+SHA3-384 | N ( >=0 ) -bytes message | 48 -bytes digest | Given N -bytes input message, this routine computes 48 -bytes sha3-384 digest, while *(incrementally)* consuming message into Keccak[768] sponge. | [`sha3_384::sha3_384_t`](./include/sha3_384.hpp)
+SHA3-512 | N ( >=0 ) -bytes message | 64 -bytes digest | Given N -bytes input message, this routine computes 64 -bytes sha3-512 digest, while *(incrementally)* consuming message into Keccak[1024] sponge. | [`sha3_512::sha3_512_t`](./include/sha3_512.hpp)
+SHAKE-128 | N ( >=0 ) -bytes message | M ( >=0 ) -bytes output | Given N -bytes input message, this routine squeezes arbitrary ( = M ) number of output bytes from Keccak[256] sponge, which has already *(incrementally)* absorbed input bytes. | [`shake128::shake128_t`](./include/shake128.hpp)
+SHAKE-256 | N ( >=0 ) -bytes message | M ( >=0 ) -bytes digest | Given N -bytes input message, this routine squeezes arbitrary ( = M ) number of output bytes from Keccak[512] sponge, which has already *(incrementally)* absorbed input bytes. | [`shake256::shake256_t`](./include/shake256.hpp)
 
 > **Note** Learn more about NIST PQC standardization effort [here](https://csrc.nist.gov/projects/post-quantum-cryptography/).
 
@@ -36,10 +41,10 @@ SHAKE-256 | N ( >=0 ) -bytes message | M ( >=0 ) -bytes digest | Given N -bytes 
 
 ```bash
 $ g++ --version
-g++ (Ubuntu 12.2.0-17ubuntu1) 12.2.0
+g++ (Ubuntu 13.1.0-2ubuntu2~23.04) 13.1.0
 
 $ clang++ --version
-Ubuntu clang version 15.0.7
+Ubuntu clang version 16.0.0 (1~exp5ubuntu3)
 Target: x86_64-pc-linux-gnu
 Thread model: posix
 InstalledDir: /usr/bin
@@ -72,46 +77,60 @@ I also test correctness of
 - Incremental message absorption property of SHA3 hash functions and Xofs.
 - Incremental output squeezing property of SHA3 Xofs.
 
+Some compile-time executed tests ( using `static_assert` ) are also implemented, which ensure that all Sha3 hash functions and xofs are `constexpr` - meaning they can be evaluated during compilation-time for any statically defined input message.
+
 Issue following command for running all the test cases.
 
 ```bash
 $ make -j8
 
-[==========] Running 12 tests from 2 test suites.
+[==========] Running 18 tests from 2 test suites.
 [----------] Global test environment set-up.
-[----------] 8 tests from Sha3Hashing
+[----------] 12 tests from Sha3Hashing
+[ RUN      ] Sha3Hashing.CompileTimeEvalSha3_224
+[       OK ] Sha3Hashing.CompileTimeEvalSha3_224 (0 ms)
 [ RUN      ] Sha3Hashing.Sha3_224IncrementalAbsorption
 [       OK ] Sha3Hashing.Sha3_224IncrementalAbsorption (1 ms)
 [ RUN      ] Sha3Hashing.Sha3_224KnownAnswerTests
 [       OK ] Sha3Hashing.Sha3_224KnownAnswerTests (2 ms)
+[ RUN      ] Sha3Hashing.CompileTimeEvalSha3_256
+[       OK ] Sha3Hashing.CompileTimeEvalSha3_256 (0 ms)
 [ RUN      ] Sha3Hashing.Sha3_256IncrementalAbsorption
 [       OK ] Sha3Hashing.Sha3_256IncrementalAbsorption (1 ms)
 [ RUN      ] Sha3Hashing.Sha3_256KnownAnswerTests
 [       OK ] Sha3Hashing.Sha3_256KnownAnswerTests (2 ms)
+[ RUN      ] Sha3Hashing.CompileTimeEvalSha3_384
+[       OK ] Sha3Hashing.CompileTimeEvalSha3_384 (0 ms)
 [ RUN      ] Sha3Hashing.Sha3_384IncrementalAbsorption
 [       OK ] Sha3Hashing.Sha3_384IncrementalAbsorption (1 ms)
 [ RUN      ] Sha3Hashing.Sha3_384KnownAnswerTests
 [       OK ] Sha3Hashing.Sha3_384KnownAnswerTests (2 ms)
+[ RUN      ] Sha3Hashing.CompileTimeEvalSha3_512
+[       OK ] Sha3Hashing.CompileTimeEvalSha3_512 (0 ms)
 [ RUN      ] Sha3Hashing.Sha3_512IncrementalAbsorption
 [       OK ] Sha3Hashing.Sha3_512IncrementalAbsorption (2 ms)
 [ RUN      ] Sha3Hashing.Sha3_512KnownAnswerTests
 [       OK ] Sha3Hashing.Sha3_512KnownAnswerTests (3 ms)
-[----------] 8 tests from Sha3Hashing (17 ms total)
+[----------] 12 tests from Sha3Hashing (18 ms total)
 
-[----------] 4 tests from Sha3Xof
+[----------] 6 tests from Sha3Xof
+[ RUN      ] Sha3Xof.CompileTimeEvalShake128
+[       OK ] Sha3Xof.CompileTimeEvalShake128 (0 ms)
 [ RUN      ] Sha3Xof.Shake128IncrementalAbsorptionAndSqueezing
-[       OK ] Sha3Xof.Shake128IncrementalAbsorptionAndSqueezing (971 ms)
+[       OK ] Sha3Xof.Shake128IncrementalAbsorptionAndSqueezing (994 ms)
 [ RUN      ] Sha3Xof.Shake128KnownAnswerTests
 [       OK ] Sha3Xof.Shake128KnownAnswerTests (2 ms)
+[ RUN      ] Sha3Xof.CompileTimeEvalShake256
+[       OK ] Sha3Xof.CompileTimeEvalShake256 (0 ms)
 [ RUN      ] Sha3Xof.Shake256IncrementalAbsorptionAndSqueezing
-[       OK ] Sha3Xof.Shake256IncrementalAbsorptionAndSqueezing (1060 ms)
+[       OK ] Sha3Xof.Shake256IncrementalAbsorptionAndSqueezing (1065 ms)
 [ RUN      ] Sha3Xof.Shake256KnownAnswerTests
-[       OK ] Sha3Xof.Shake256KnownAnswerTests (2 ms)
-[----------] 4 tests from Sha3Xof (2038 ms total)
+[       OK ] Sha3Xof.Shake256KnownAnswerTests (3 ms)
+[----------] 6 tests from Sha3Xof (2066 ms total)
 
 [----------] Global test environment tear-down
-[==========] 12 tests from 2 test suites ran. (2055 ms total)
-[  PASSED  ] 12 tests.
+[==========] 18 tests from 2 test suites ran. (2085 ms total)
+[  PASSED  ] 18 tests.
 ```
 
 ## Benchmarking
@@ -132,92 +151,92 @@ make benchmark # Or you can simply use this.
 ### On 12th Gen Intel(R) Core(TM) i7-1260P ( compiled with GCC )
 
 ```bash
-2023-07-11T09:18:28+04:00
+2023-08-06T12:42:35+04:00
 Running ./benchmarks/perf.out
-Run on (16 X 601.957 MHz CPU s)
+Run on (16 X 1126.69 MHz CPU s)
 CPU Caches:
   L1 Data 48 KiB (x8)
   L1 Instruction 32 KiB (x8)
   L2 Unified 1280 KiB (x8)
   L3 Unified 18432 KiB (x1)
-Load Average: 0.20, 0.49, 0.56
+Load Average: 0.72, 0.77, 0.66
 ***WARNING*** There are 65 benchmarks with threads and 2 performance counters were requested. Beware counters will reflect the combined usage across all threads.
 -------------------------------------------------------------------------------------------------------------------------------------------------
 Benchmark                             Time             CPU   Iterations     CYCLES CYCLES/ BYTE INSTRUCTIONS INSTRUCTIONS/ CYCLE bytes_per_second
 -------------------------------------------------------------------------------------------------------------------------------------------------
-bench_sha3::keccakf1600             204 ns          204 ns      3382741    952.497      4.76249       5.689k             5.97272       935.552M/s
-bench_sha3::sha3_224/32             238 ns          238 ns      2944147   1.11184k      18.5306       5.906k             5.31194       240.608M/s
-bench_sha3::sha3_224/64             237 ns          237 ns      2956947   1.10706k      12.0333       5.906k             5.33485       370.651M/s
-bench_sha3::sha3_224/128            235 ns          235 ns      2979980       1096      7.02566       5.916k              5.3978       634.041M/s
-bench_sha3::sha3_224/256            438 ns          438 ns      1598391   2.04883k       7.2142      11.649k             5.68568       617.827M/s
-bench_sha3::sha3_224/512            881 ns          881 ns       785228   4.12282k      7.63485      23.071k             5.59593       584.467M/s
-bench_sha3::sha3_224/1024          1768 ns         1768 ns       396226   8.26518k      7.85664      45.904k              5.5539       567.618M/s
-bench_sha3::sha3_224/2048          3323 ns         3323 ns       210738   15.5442k      7.48756      85.882k             5.52503       595.884M/s
-bench_sha3::sha3_224/4096          6446 ns         6446 ns       108536   30.1042k      7.29976     165.836k             5.50873        610.16M/s
-bench_sha3::sha3_256/32             240 ns          240 ns      2916048   1.12198k       17.531       5.953k             5.30579       254.407M/s
-bench_sha3::sha3_256/64             239 ns          239 ns      2918469   1.11947k      11.6612       5.953k             5.31767        382.34M/s
-bench_sha3::sha3_256/128            237 ns          237 ns      2950765   1.10777k      6.92358       5.963k             5.38287       643.691M/s
-bench_sha3::sha3_256/256            467 ns          466 ns      1499310   2.18082k      7.57231      12.336k             5.65658       588.802M/s
-bench_sha3::sha3_256/512            974 ns          974 ns       712676   4.54354k       8.3521      25.048k             5.51288       532.626M/s
-bench_sha3::sha3_256/1024          2001 ns         2001 ns       350507   9.28836k       8.7958      50.472k              5.4339       503.398M/s
-bench_sha3::sha3_256/2048          4077 ns         4077 ns       171979   18.7672k       9.0227     101.311k              5.3983       486.539M/s
-bench_sha3::sha3_256/4096          7951 ns         7950 ns        87327   36.5089k      8.84421     196.649k             5.38633       495.208M/s
-bench_sha3::sha3_384/32             237 ns          237 ns      2950914    1096.34      13.7042       5.938k             5.41621       321.547M/s
-bench_sha3::sha3_384/64             237 ns          237 ns      2942018    1090.68      9.73821       5.938k             5.44431       450.048M/s
-bench_sha3::sha3_384/128            436 ns          436 ns      1604990   1.98857k      11.2987      11.758k             5.91278       384.784M/s
-bench_sha3::sha3_384/256            654 ns          654 ns      1074396   2.97678k      9.79203      17.569k             5.90202       443.049M/s
-bench_sha3::sha3_384/512           1090 ns         1090 ns       647333   4.96156k      8.85992      29.199k             5.88505       489.793M/s
-bench_sha3::sha3_384/1024          2176 ns         2176 ns       320268    9.9223k      9.25588      58.249k             5.87051       469.873M/s
-bench_sha3::sha3_384/2048          4366 ns         4366 ns       160521   19.8368k      9.46412     116.349k             5.86531       457.868M/s
-bench_sha3::sha3_384/4096          8739 ns         8739 ns        80166   39.6558k      9.56944     232.539k             5.86394       452.254M/s
-bench_sha3::sha3_512/32             239 ns          239 ns      2922842    1084.61       11.298       5.915k             5.45357        383.06M/s
-bench_sha3::sha3_512/64             239 ns          239 ns      2937449    1081.56      8.44968       5.915k             5.46896       510.621M/s
-bench_sha3::sha3_512/128            439 ns          439 ns      1589147   1.98287k      10.3275      11.696k             5.89851       416.669M/s
-bench_sha3::sha3_512/256            872 ns          872 ns       799908   3.94609k      12.3315      23.234k             5.88785       349.834M/s
-bench_sha3::sha3_512/512           1748 ns         1748 ns       400630   7.88841k      13.6952      46.311k             5.87076       314.308M/s
-bench_sha3::sha3_512/1024          3267 ns         3266 ns       213289   14.7807k      13.5852      86.692k             5.86523       317.684M/s
-bench_sha3::sha3_512/2048          6347 ns         6346 ns       110975   28.6202k      13.5513     167.459k             5.85107       317.368M/s
-bench_sha3::sha3_512/4096         12418 ns        12417 ns        56733   56.0995k      13.4854     328.991k             5.86442       319.508M/s
-bench_sha3::shake128/32/32          241 ns          241 ns      2908442    1092.45      17.0695       5.798k             5.30735        253.49M/s
-bench_sha3::shake128/64/32          241 ns          241 ns      2910706    1091.36      11.3683       5.798k             5.31265       379.296M/s
-bench_sha3::shake128/128/32         242 ns          242 ns      2910558    1091.42      6.82136       5.808k             5.32152        631.03M/s
-bench_sha3::shake128/256/32         459 ns          459 ns      1522674   2.07959k       7.2208       11.78k             5.66458       597.995M/s
-bench_sha3::shake128/512/32         943 ns          943 ns       744327    4.2413k      7.79651      23.681k             5.58343       549.972M/s
-bench_sha3::shake128/1024/32       1659 ns         1659 ns       421970   7.47771k      7.08116      41.544k             5.55571       607.027M/s
-bench_sha3::shake128/2048/32       3118 ns         3118 ns       224275   13.9865k      6.72428      77.275k             5.52497        636.24M/s
-bench_sha3::shake128/4096/32       5992 ns         5991 ns       117529   26.9722k      6.53397     148.735k             5.51438       657.067M/s
-bench_sha3::shake128/32/64          240 ns          240 ns      2914777     1092.4      11.3792       5.798k             5.30758       380.773M/s
-bench_sha3::shake128/64/64          240 ns          240 ns      2898743    1091.47      8.52711       5.798k              5.3121       507.998M/s
-bench_sha3::shake128/128/64         241 ns          241 ns      2905659     1091.6      5.68542       5.808k             5.32063       759.543M/s
-bench_sha3::shake128/256/64         460 ns          460 ns      1521896   2.07749k      6.49215       11.78k             5.67031        663.37M/s
-bench_sha3::shake128/512/64         944 ns          944 ns       742232   4.23709k      7.35607      23.681k             5.58897       581.721M/s
-bench_sha3::shake128/1024/64       1674 ns         1674 ns       420158   7.48884k      6.88313      41.544k             5.54745       619.997M/s
-bench_sha3::shake128/2048/64       3123 ns         3122 ns       224317   13.9777k      6.61823      77.275k             5.52845       645.096M/s
-bench_sha3::shake128/4096/64       6022 ns         6021 ns       117146   26.9551k       6.4796     148.735k             5.51787        658.88M/s
-bench_sha3::shake256/32/32          249 ns          249 ns      2812374    1.1233k      17.5516       5.869k             5.22477       244.991M/s
-bench_sha3::shake256/64/32          249 ns          249 ns      2803444   1.12052k      11.6721       5.869k             5.23775       367.748M/s
-bench_sha3::shake256/128/32         247 ns          247 ns      2818505   1.10777k      6.92355       5.879k             5.30707       618.551M/s
-bench_sha3::shake256/256/32         468 ns          468 ns      1493478   2.10194k      7.29841      11.916k             5.66904       587.218M/s
-bench_sha3::shake256/512/32         955 ns          955 ns       730431   4.27319k      7.85514      23.954k             5.60564       543.478M/s
-bench_sha3::shake256/1024/32       1927 ns         1927 ns       361182    8.6278k      8.17026       48.03k             5.56689       522.707M/s
-bench_sha3::shake256/2048/32       3892 ns         3892 ns       180625   17.3318k      8.33258      96.173k             5.54894       509.653M/s
-bench_sha3::shake256/4096/32       7502 ns         7501 ns        92328   33.6069k       8.1412     186.456k             5.54815       524.856M/s
-bench_sha3::shake256/32/64          249 ns          249 ns      2793855   1.12242k      11.6919       5.869k             5.22887       367.932M/s
-bench_sha3::shake256/64/64          248 ns          248 ns      2814934   1.12097k      8.75759       5.869k             5.23564       491.418M/s
-bench_sha3::shake256/128/64         247 ns          247 ns      2836927   1.10692k       5.7652       5.879k             5.31114       740.755M/s
-bench_sha3::shake256/256/64         470 ns          469 ns      1493341   2.10326k      6.57269      11.916k             5.66549       650.027M/s
-bench_sha3::shake256/512/64         956 ns          956 ns       732281   4.27517k      7.42216      23.954k             5.60306       574.727M/s
-bench_sha3::shake256/1024/64       1946 ns         1945 ns       362132   8.62615k      7.92844       48.03k             5.56796       533.376M/s
-bench_sha3::shake256/2048/64       3910 ns         3910 ns       179003   17.3289k      8.20496      96.173k             5.54987       515.158M/s
-bench_sha3::shake256/4096/64       7614 ns         7612 ns        91960   33.6347k      8.08525     186.456k             5.54357       521.159M/s
+bench_sha3::keccakf1600             215 ns          215 ns      3252501    958.826      4.79413       5.725k             5.97084       885.488M/s
+bench_sha3::sha3_224/32             258 ns          258 ns      2714523   1.14981k      19.1635       6.088k             5.29479       222.178M/s
+bench_sha3::sha3_224/64             257 ns          257 ns      2721160   1.13936k      12.3844       6.088k             5.34333       341.217M/s
+bench_sha3::sha3_224/128            256 ns          256 ns      2721895    1.1275k      7.22757       6.098k             5.40842       580.521M/s
+bench_sha3::sha3_224/256            470 ns          471 ns      1494477   2.07718k        7.314      11.832k             5.69619       575.586M/s
+bench_sha3::sha3_224/512            951 ns          951 ns       732717   4.17011k      7.72243      23.264k             5.57875       541.539M/s
+bench_sha3::sha3_224/1024          1911 ns         1912 ns       364988   8.34463k      7.93215      46.117k             5.52655       524.808M/s
+bench_sha3::sha3_224/2048          3604 ns         3605 ns       193716   15.6681k      7.54723       86.13k             5.49717       549.239M/s
+bench_sha3::sha3_224/4096          6979 ns         6980 ns       100880   30.3317k      7.35493     166.154k             5.47789       563.482M/s
+bench_sha3::sha3_256/32             266 ns          266 ns      2633906   1.15671k      18.0737       6.083k             5.25886       229.526M/s
+bench_sha3::sha3_256/64             264 ns          264 ns      2653244     1.144k      11.9167       6.083k             5.31731       346.923M/s
+bench_sha3::sha3_256/128            263 ns          263 ns      2648918   1.13429k      7.08929       6.093k             5.37166       579.285M/s
+bench_sha3::sha3_256/256            510 ns          511 ns      1375345    2.1968k      7.62776       12.59k             5.73107       537.984M/s
+bench_sha3::sha3_256/512           1056 ns         1056 ns       663524   4.51611k      8.30168      25.548k             5.65708       491.438M/s
+bench_sha3::sha3_256/1024          2154 ns         2154 ns       326352   9.15949k      8.67376      51.464k             5.61865       467.442M/s
+bench_sha3::sha3_256/2048          4320 ns         4320 ns       162150   18.4495k      8.86996     103.287k             5.59836       459.151M/s
+bench_sha3::sha3_256/4096          8378 ns         8379 ns        83662   35.7843k      8.66868      200.47k             5.60218       469.818M/s
+bench_sha3::sha3_384/32             251 ns          251 ns      2780712    1080.99      13.5124        6.18k             5.71697       303.684M/s
+bench_sha3::sha3_384/64             252 ns          252 ns      2776134    1083.49      9.67401        6.18k              5.7038       423.275M/s
+bench_sha3::sha3_384/128            478 ns          478 ns      1465835   2.04213k       11.603      12.038k             5.89482       351.329M/s
+bench_sha3::sha3_384/256            711 ns          711 ns       985212   3.02232k      9.94185     17.8171k             5.89516       407.977M/s
+bench_sha3::sha3_384/512           1180 ns         1181 ns       589339   5.02766k      8.97796      29.563k             5.88008       452.368M/s
+bench_sha3::sha3_384/1024          2339 ns         2339 ns       298201   9.98902k      9.31811      58.753k             5.88176       437.054M/s
+bench_sha3::sha3_384/2048          4689 ns         4690 ns       149894   19.9591k      9.52248     117.133k             5.86864       426.214M/s
+bench_sha3::sha3_384/4096          9365 ns         9366 ns        74481   39.8012k      9.60453     233.883k             5.87629       421.944M/s
+bench_sha3::sha3_512/32             250 ns          250 ns      2801202    1063.64      11.0796       5.977k             5.61936       366.876M/s
+bench_sha3::sha3_512/64             250 ns          250 ns      2815614    1057.31      8.26026       5.977k             5.65301       488.766M/s
+bench_sha3::sha3_512/128            483 ns          483 ns      1448948   2.05695k      10.7133      12.104k             5.88444        378.98M/s
+bench_sha3::sha3_512/256            973 ns          973 ns       720554   4.14606k      12.9564      24.332k              5.8687       313.546M/s
+bench_sha3::sha3_512/512           1949 ns         1949 ns       358595   8.34309k      14.4845      48.789k             5.84783       281.814M/s
+bench_sha3::sha3_512/1024          3791 ns         3791 ns       179316   16.2029k      14.8924      91.585k             5.65237       273.687M/s
+bench_sha3::sha3_512/2048          7113 ns         7114 ns        98033   30.4241k      14.4054     177.182k             5.82374       283.128M/s
+bench_sha3::sha3_512/4096         13969 ns        13971 ns        50154   59.6554k      14.3402     348.374k             5.83977       283.964M/s
+bench_sha3::shake128/32/32          286 ns          286 ns      2448824   1.21742k      19.0221       6.473k               5.317        213.46M/s
+bench_sha3::shake128/64/32          284 ns          285 ns      2463723   1.20557k       12.558       6.473k             5.36927       321.784M/s
+bench_sha3::shake128/128/32         285 ns          285 ns      2468293   1.20591k      7.53695       6.483k             5.37602       536.013M/s
+bench_sha3::shake128/256/32         518 ns          518 ns      1342117   2.19534k      7.62272      12.299k             5.60231       529.889M/s
+bench_sha3::shake128/512/32        1012 ns         1012 ns       690130   4.28544k      7.87766       23.88k             5.57235       512.544M/s
+bench_sha3::shake128/1024/32       1753 ns         1754 ns       399707    7.4415k      7.04687      41.263k             5.54499       574.254M/s
+bench_sha3::shake128/2048/32       3205 ns         3205 ns       216136   13.7278k       6.5999     75.9721k             5.53419       618.934M/s
+bench_sha3::shake128/4096/32       5956 ns         5957 ns       117343   26.3739k      6.38902     145.574k             5.51963       660.885M/s
+bench_sha3::shake128/32/64          274 ns          274 ns      2543979   1.22178k      12.7269       6.473k               5.298       333.549M/s
+bench_sha3::shake128/64/64          277 ns          277 ns      2569840   1.20788k      9.43658       6.473k             5.35897        441.37M/s
+bench_sha3::shake128/128/64         285 ns          285 ns      2453965   1.20748k      6.28894       6.483k             5.36904       642.662M/s
+bench_sha3::shake128/256/64         519 ns          519 ns      1347704   2.19589k      6.86215      12.299k             5.60093       587.764M/s
+bench_sha3::shake128/512/64        1012 ns         1013 ns       684498   4.28868k      7.44563       23.88k             5.56814       542.467M/s
+bench_sha3::shake128/1024/64       1774 ns         1774 ns       398184    7.4383k      6.83667      41.263k             5.54737       584.882M/s
+bench_sha3::shake128/2048/64       3262 ns         3262 ns       214161   13.7421k       6.5067      76.034k             5.53291       617.423M/s
+bench_sha3::shake128/4096/64       6250 ns         6251 ns       112566   26.3732k      6.33972     145.574k             5.51977       634.651M/s
+bench_sha3::shake256/32/32          281 ns          281 ns      2491300   1.19174k      18.6209       6.191k             5.19494       217.215M/s
+bench_sha3::shake256/64/32          278 ns          278 ns      2512517   1.18054k      12.2973       6.191k             5.24422         328.9M/s
+bench_sha3::shake256/128/32         280 ns          280 ns      2508561   1.18298k      7.39365       6.201k             5.24183        545.77M/s
+bench_sha3::shake256/256/32         502 ns          502 ns      1397585   2.12123k      7.36539      12.148k             5.72686       547.578M/s
+bench_sha3::shake256/512/32        1008 ns         1008 ns       692518    4.2558k      7.82316          24k             5.63936       514.549M/s
+bench_sha3::shake256/1024/32       2023 ns         2023 ns       345617   8.52332k      8.07132      47.704k             5.59688       497.832M/s
+bench_sha3::shake256/2048/32       4055 ns         4055 ns       171971   17.0938k      8.21819      95.103k             5.56358       489.181M/s
+bench_sha3::shake256/4096/32       7892 ns         7892 ns        89639   33.1722k      8.03589     183.991k             5.54655       498.813M/s
+bench_sha3::shake256/32/64          280 ns          280 ns      2493822   1.19248k      12.4217       6.191k             5.19169       326.418M/s
+bench_sha3::shake256/64/64          278 ns          278 ns      2510855   1.18261k       9.2391       6.191k             5.23505       438.551M/s
+bench_sha3::shake256/128/64         279 ns          279 ns      2508278   1.18189k      6.15569       6.201k             5.24667       657.321M/s
+bench_sha3::shake256/256/64         502 ns          502 ns      1394148    2.0532k      6.41626     11.7545k             5.72495       607.658M/s
+bench_sha3::shake256/512/64         986 ns          986 ns       720022   4.15368k      7.21125     23.4026k             5.63419       556.862M/s
+bench_sha3::shake256/1024/64       1974 ns         1974 ns       354117   8.53791k      7.84735      47.704k             5.58731        525.56M/s
+bench_sha3::shake256/2048/64       3925 ns         3925 ns       177954   17.1122k      8.10235      95.103k             5.55763        513.12M/s
+bench_sha3::shake256/4096/64       7629 ns         7630 ns        91841   33.1481k       7.9683     183.991k             5.55057       519.982M/s
 ```
 
 ## Usage
 
 `sha3` - C++ header-only library is written such that it's fairly easy for one to start using it in their project. All one needs to do
 
-- Include proper header files ( select what you need by name ).
-- Use proper struct(s)/ API(s)/ constant(s) ( see [usage examples](./example) or [test cases](./include/tests) ).
+- Include proper header files ( select which scheme you need by name ).
+- Use proper struct(s)/ API(s)/ constant(s) ( see [usage examples](./example) or [test cases](./tests/) ).
 - When compiling, let your compiler know where it can find respective header files, which is `./include` directory.
 
 Scheme | Header | Namespace | Example
@@ -228,6 +247,51 @@ SHA3-384 | ./include/sha3_384.hpp | `sha3_384::` | [example/sha3_384.cpp](./exam
 SHA3-512 | ./include/sha3_512.hpp | `sha3_512::` | [example/sha3_512.cpp](./example/sha3_512.cpp)
 SHAKE128 | ./include/shake128.hpp | `shake128::` | [example/shake128.cpp](./example/shake128.cpp)
 SHAKE256 | ./include/shake256.hpp | `shake256::` | [example/shake256.cpp](./example/shake256.cpp)
+
+As this library implements all Sha3 hash functions and xofs as `constexpr` - one can evaluate say Sha3-256 digest of some statically defined input message during program compilation time. Let's see how to do that and for ensuring that it computes correct message digest, we'll use static assertions.
+
+```cpp
+#include "sha3_256.hpp"
+
+// Eval SHA3-256 hash on statically defined input message during
+// compilation-time.
+constexpr std::array<uint8_t, sha3_256::DIGEST_LEN>
+eval_sha3_256()
+{
+  // Statically defined input.
+  std::array<uint8_t, sha3_256::DIGEST_LEN * 2> data{};
+  std::iota(data.begin(), data.end(), 0);
+
+  // To be computed output.
+  std::array<uint8_t, sha3_256::DIGEST_LEN> md{};
+
+  sha3_256::sha3_256_t hasher;
+  hasher.absorb(data);
+  hasher.finalize();
+  hasher.digest(md);
+
+  return md;
+}
+
+int
+main()
+{
+
+  // Input  = 000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f
+  // Output = c8ad478f4e1dd9d47dfc3b985708d92db1f8db48fe9cddd459e63c321f490402
+  constexpr auto md = eval_sha3_256();
+  static_assert(md ==
+                  std::array<uint8_t, sha3_256::DIGEST_LEN>{
+                    200, 173, 71, 143, 78, 29,  217, 212, 125, 252, 59,
+                    152, 87,  8,  217, 45, 177, 248, 219, 72,  254, 156,
+                    221, 212, 89, 230, 60, 50,  31,  73,  4,   2 },
+                "Must be able to compute Sha3-256 hash during compile-time !");
+
+  return 0;
+}
+```
+
+I maintain examples of using Sha3 hash function and xof API, inside [examples](./example/) directory.
 
 ```bash
 $ g++ -std=c++20 -Wall -O3 -march=native -I include example/sha3_224.cpp && ./a.out

--- a/example/sha3_224.cpp
+++ b/example/sha3_224.cpp
@@ -14,13 +14,14 @@ main()
 
   std::vector<uint8_t> msg(ilen, 0);
   std::vector<uint8_t> dig(olen, 0);
+  auto _dig = std::span<uint8_t, olen>(dig);
 
-  sha3_utils::random_data<uint8_t>(msg.data(), msg.size());
+  sha3_utils::random_data<uint8_t>(msg);
 
-  sha3_224::sha3_224 hasher;
-  hasher.absorb(msg.data(), msg.size());
+  sha3_224::sha3_224_t hasher;
+  hasher.absorb(msg);
   hasher.finalize();
-  hasher.digest(dig.data());
+  hasher.digest(_dig);
 
   std::cout << "SHA3-224" << std::endl << std::endl;
   std::cout << "Input  : " << sha3_utils::to_hex(msg.data(), ilen) << "\n";

--- a/example/sha3_256.cpp
+++ b/example/sha3_256.cpp
@@ -14,13 +14,14 @@ main()
 
   std::vector<uint8_t> msg(ilen, 0);
   std::vector<uint8_t> dig(olen, 0);
+  auto _dig = std::span<uint8_t, olen>(dig);
 
-  sha3_utils::random_data<uint8_t>(msg.data(), msg.size());
+  sha3_utils::random_data<uint8_t>(msg);
 
-  sha3_256::sha3_256 hasher;
-  hasher.absorb(msg.data(), msg.size());
+  sha3_256::sha3_256_t hasher;
+  hasher.absorb(msg);
   hasher.finalize();
-  hasher.digest(dig.data());
+  hasher.digest(_dig);
 
   std::cout << "SHA3-256" << std::endl << std::endl;
   std::cout << "Input  : " << sha3_utils::to_hex(msg.data(), ilen) << "\n";

--- a/example/sha3_384.cpp
+++ b/example/sha3_384.cpp
@@ -14,13 +14,14 @@ main()
 
   std::vector<uint8_t> msg(ilen, 0);
   std::vector<uint8_t> dig(olen, 0);
+  auto _dig = std::span<uint8_t, olen>(dig);
 
-  sha3_utils::random_data<uint8_t>(msg.data(), msg.size());
+  sha3_utils::random_data<uint8_t>(msg);
 
-  sha3_384::sha3_384 hasher;
-  hasher.absorb(msg.data(), msg.size());
+  sha3_384::sha3_384_t hasher;
+  hasher.absorb(msg);
   hasher.finalize();
-  hasher.digest(dig.data());
+  hasher.digest(_dig);
 
   std::cout << "SHA3-384" << std::endl << std::endl;
   std::cout << "Input  : " << sha3_utils::to_hex(msg.data(), ilen) << "\n";

--- a/example/sha3_512.cpp
+++ b/example/sha3_512.cpp
@@ -14,13 +14,14 @@ main()
 
   std::vector<uint8_t> msg(ilen, 0);
   std::vector<uint8_t> dig(olen, 0);
+  auto _dig = std::span<uint8_t, olen>(dig);
 
-  sha3_utils::random_data<uint8_t>(msg.data(), msg.size());
+  sha3_utils::random_data<uint8_t>(msg);
 
-  sha3_512::sha3_512 hasher;
-  hasher.absorb(msg.data(), msg.size());
+  sha3_512::sha3_512_t hasher;
+  hasher.absorb(msg);
   hasher.finalize();
-  hasher.digest(dig.data());
+  hasher.digest(_dig);
 
   std::cout << "SHA3-512" << std::endl << std::endl;
   std::cout << "Input  : " << sha3_utils::to_hex(msg.data(), ilen) << "\n";

--- a/example/shake128.cpp
+++ b/example/shake128.cpp
@@ -14,14 +14,15 @@ main()
 
   std::vector<uint8_t> msg(ilen, 0);
   std::vector<uint8_t> dig(olen, 0);
+  auto _dig = std::span(dig);
 
-  sha3_utils::random_data<uint8_t>(msg.data(), msg.size());
+  sha3_utils::random_data<uint8_t>(msg);
 
   // Create shake128 hasher
-  shake128::shake128 hasher;
+  shake128::shake128_t hasher;
 
   // Absorb message bytes into sponge state
-  hasher.absorb(msg.data(), msg.size());
+  hasher.absorb(msg);
   // Finalize sponge state
   hasher.finalize();
 
@@ -29,7 +30,7 @@ main()
   // One can request arbitrary many bytes of output, by calling `squeeze`
   // arbitrary many times.
   for (size_t i = 0; i < olen; i++) {
-    hasher.squeeze(dig.data() + i, 1);
+    hasher.squeeze(_dig.subspan(i, 1));
   }
 
   std::cout << "SHAKE-128" << std::endl << std::endl;

--- a/example/shake256.cpp
+++ b/example/shake256.cpp
@@ -14,14 +14,15 @@ main()
 
   std::vector<uint8_t> msg(ilen, 0);
   std::vector<uint8_t> dig(olen, 0);
+  auto _dig = std::span(dig);
 
-  sha3_utils::random_data<uint8_t>(msg.data(), msg.size());
+  sha3_utils::random_data<uint8_t>(msg);
 
   // Create shake256 hasher
-  shake256::shake256 hasher;
+  shake256::shake256_t hasher;
 
   // Absorb message bytes into sponge state
-  hasher.absorb(msg.data(), msg.size());
+  hasher.absorb(msg);
   // Finalize sponge state
   hasher.finalize();
 
@@ -29,7 +30,7 @@ main()
   // One can request arbitrary many bytes of output, by calling `squeeze`
   // arbitrary many times.
   for (size_t i = 0; i < olen; i++) {
-    hasher.squeeze(dig.data() + i, 1);
+    hasher.squeeze(_dig.subspan(i, 1));
   }
 
   std::cout << "SHAKE-256" << std::endl << std::endl;

--- a/include/benchmarks/bench_hashing.hpp
+++ b/include/benchmarks/bench_hashing.hpp
@@ -21,7 +21,7 @@ sha3_224(benchmark::State& state)
   sha3_utils::random_data(msg.data(), msg.size());
 
   for (auto _ : state) {
-    sha3_224::sha3_224 hasher;
+    sha3_224::sha3_224_t hasher;
     hasher.absorb(msg.data(), msg.size());
     hasher.finalize();
     hasher.digest(md.data());
@@ -57,7 +57,7 @@ sha3_256(benchmark::State& state)
   sha3_utils::random_data(msg.data(), msg.size());
 
   for (auto _ : state) {
-    sha3_256::sha3_256 hasher;
+    sha3_256::sha3_256_t hasher;
     hasher.absorb(msg.data(), msg.size());
     hasher.finalize();
     hasher.digest(md.data());
@@ -93,7 +93,7 @@ sha3_384(benchmark::State& state)
   sha3_utils::random_data(msg.data(), msg.size());
 
   for (auto _ : state) {
-    sha3_384::sha3_384 hasher;
+    sha3_384::sha3_384_t hasher;
     hasher.absorb(msg.data(), msg.size());
     hasher.finalize();
     hasher.digest(md.data());
@@ -129,7 +129,7 @@ sha3_512(benchmark::State& state)
   sha3_utils::random_data(msg.data(), msg.size());
 
   for (auto _ : state) {
-    sha3_512::sha3_512 hasher;
+    sha3_512::sha3_512_t hasher;
     hasher.absorb(msg.data(), msg.size());
     hasher.finalize();
     hasher.digest(md.data());

--- a/include/benchmarks/bench_hashing.hpp
+++ b/include/benchmarks/bench_hashing.hpp
@@ -17,18 +17,19 @@ sha3_224(benchmark::State& state)
 
   std::vector<uint8_t> msg(mlen);
   std::vector<uint8_t> md(sha3_224::DIGEST_LEN);
+  auto _md = std::span<uint8_t, sha3_224::DIGEST_LEN>(md);
 
-  sha3_utils::random_data(msg.data(), msg.size());
+  sha3_utils::random_data<uint8_t>(msg);
 
   for (auto _ : state) {
     sha3_224::sha3_224_t hasher;
-    hasher.absorb(msg.data(), msg.size());
+    hasher.absorb(msg);
     hasher.finalize();
-    hasher.digest(md.data());
+    hasher.digest(_md);
 
     benchmark::DoNotOptimize(hasher);
     benchmark::DoNotOptimize(msg);
-    benchmark::DoNotOptimize(md);
+    benchmark::DoNotOptimize(_md);
     benchmark::ClobberMemory();
   }
 
@@ -53,18 +54,19 @@ sha3_256(benchmark::State& state)
 
   std::vector<uint8_t> msg(mlen);
   std::vector<uint8_t> md(sha3_256::DIGEST_LEN);
+  auto _md = std::span<uint8_t, sha3_256::DIGEST_LEN>(md);
 
-  sha3_utils::random_data(msg.data(), msg.size());
+  sha3_utils::random_data<uint8_t>(msg);
 
   for (auto _ : state) {
     sha3_256::sha3_256_t hasher;
-    hasher.absorb(msg.data(), msg.size());
+    hasher.absorb(msg);
     hasher.finalize();
-    hasher.digest(md.data());
+    hasher.digest(_md);
 
     benchmark::DoNotOptimize(hasher);
     benchmark::DoNotOptimize(msg);
-    benchmark::DoNotOptimize(md);
+    benchmark::DoNotOptimize(_md);
     benchmark::ClobberMemory();
   }
 
@@ -89,18 +91,19 @@ sha3_384(benchmark::State& state)
 
   std::vector<uint8_t> msg(mlen);
   std::vector<uint8_t> md(sha3_384::DIGEST_LEN);
+  auto _md = std::span<uint8_t, sha3_384::DIGEST_LEN>(md);
 
-  sha3_utils::random_data(msg.data(), msg.size());
+  sha3_utils::random_data<uint8_t>(msg);
 
   for (auto _ : state) {
     sha3_384::sha3_384_t hasher;
-    hasher.absorb(msg.data(), msg.size());
+    hasher.absorb(msg);
     hasher.finalize();
-    hasher.digest(md.data());
+    hasher.digest(_md);
 
     benchmark::DoNotOptimize(hasher);
     benchmark::DoNotOptimize(msg);
-    benchmark::DoNotOptimize(md);
+    benchmark::DoNotOptimize(_md);
     benchmark::ClobberMemory();
   }
 
@@ -125,18 +128,19 @@ sha3_512(benchmark::State& state)
 
   std::vector<uint8_t> msg(mlen);
   std::vector<uint8_t> md(sha3_512::DIGEST_LEN);
+  auto _md = std::span<uint8_t, sha3_512::DIGEST_LEN>(md);
 
-  sha3_utils::random_data(msg.data(), msg.size());
+  sha3_utils::random_data<uint8_t>(msg);
 
   for (auto _ : state) {
     sha3_512::sha3_512_t hasher;
-    hasher.absorb(msg.data(), msg.size());
+    hasher.absorb(msg);
     hasher.finalize();
-    hasher.digest(md.data());
+    hasher.digest(_md);
 
     benchmark::DoNotOptimize(hasher);
     benchmark::DoNotOptimize(msg);
-    benchmark::DoNotOptimize(md);
+    benchmark::DoNotOptimize(_md);
     benchmark::ClobberMemory();
   }
 

--- a/include/benchmarks/bench_keccak.hpp
+++ b/include/benchmarks/bench_keccak.hpp
@@ -12,7 +12,7 @@ inline void
 keccakf1600(benchmark::State& state)
 {
   std::array<uint64_t, keccak::LANE_CNT> init{};
-  sha3_utils::random_data(init.data(), keccak::LANE_CNT);
+  sha3_utils::random_data<uint64_t>(init);
 
   keccak::keccak_t st(init);
 

--- a/include/benchmarks/bench_keccak.hpp
+++ b/include/benchmarks/bench_keccak.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "keccak.hpp"
 #include "utils.hpp"
+#include <array>
 #include <benchmark/benchmark.h>
 
 // Benchmarks SHA3 functions targeting CPU systems, using google-benchmark.
@@ -10,11 +11,13 @@ namespace bench_sha3 {
 inline void
 keccakf1600(benchmark::State& state)
 {
-  uint64_t st[keccak::LANE_CNT];
-  sha3_utils::random_data(st, keccak::LANE_CNT);
+  std::array<uint64_t, keccak::LANE_CNT> init{};
+  sha3_utils::random_data(init.data(), keccak::LANE_CNT);
+
+  keccak::keccak_t st(init);
 
   for (auto _ : state) {
-    keccak::permute(st);
+    st.permute();
 
     benchmark::DoNotOptimize(st);
     benchmark::ClobberMemory();

--- a/include/benchmarks/bench_xof.hpp
+++ b/include/benchmarks/bench_xof.hpp
@@ -24,7 +24,7 @@ shake128(benchmark::State& state)
   sha3_utils::random_data(msg.data(), msg.size());
 
   for (auto _ : state) {
-    shake128::shake128 hasher;
+    shake128::shake128_t hasher;
     hasher.absorb(msg.data(), msg.size());
     hasher.finalize();
     hasher.squeeze(out.data(), out.size());
@@ -65,7 +65,7 @@ shake256(benchmark::State& state)
   sha3_utils::random_data(msg.data(), msg.size());
 
   for (auto _ : state) {
-    shake256::shake256 hasher;
+    shake256::shake256_t hasher;
     hasher.absorb(msg.data(), msg.size());
     hasher.finalize();
     hasher.squeeze(out.data(), out.size());

--- a/include/benchmarks/bench_xof.hpp
+++ b/include/benchmarks/bench_xof.hpp
@@ -21,13 +21,13 @@ shake128(benchmark::State& state)
   std::vector<uint8_t> msg(mlen);
   std::vector<uint8_t> out(olen);
 
-  sha3_utils::random_data(msg.data(), msg.size());
+  sha3_utils::random_data<uint8_t>(msg);
 
   for (auto _ : state) {
     shake128::shake128_t hasher;
-    hasher.absorb(msg.data(), msg.size());
+    hasher.absorb(msg);
     hasher.finalize();
-    hasher.squeeze(out.data(), out.size());
+    hasher.squeeze(out);
 
     benchmark::DoNotOptimize(hasher);
     benchmark::DoNotOptimize(msg);
@@ -62,13 +62,13 @@ shake256(benchmark::State& state)
   std::vector<uint8_t> msg(mlen);
   std::vector<uint8_t> out(olen);
 
-  sha3_utils::random_data(msg.data(), msg.size());
+  sha3_utils::random_data<uint8_t>(msg);
 
   for (auto _ : state) {
     shake256::shake256_t hasher;
-    hasher.absorb(msg.data(), msg.size());
+    hasher.absorb(msg);
     hasher.finalize();
-    hasher.squeeze(out.data(), out.size());
+    hasher.squeeze(out);
 
     benchmark::DoNotOptimize(hasher);
     benchmark::DoNotOptimize(msg);

--- a/include/keccak.hpp
+++ b/include/keccak.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <algorithm>
 #include <array>
 #include <bit>
 #include <cstddef>
@@ -124,170 +125,208 @@ compute_rcs()
 // https://dx.doi.org/10.s6028/NIST.FIPS.202
 constexpr auto RC = compute_rcs();
 
-// Keccak-p[1600, 24] step mapping function θ, see section 3.2.1 of SHA3
-// specification https://dx.doi.org/10.6028/NIST.FIPS.202
-inline static void
-theta(uint64_t* const state)
+// 1600 -bit Keccak permutation state, on which we can apply 24 -rounds
+// permutation.
+struct keccak_t
 {
-  uint64_t c[5]{};
-  uint64_t d[5];
+private:
+  std::array<uint64_t, LANE_CNT> state{};
+
+  // Keccak-p[1600, 24] step mapping function θ, see section 3.2.1 of SHA3
+  // specification https://dx.doi.org/10.6028/NIST.FIPS.202
+  inline constexpr void theta()
+  {
+    std::array<uint64_t, 5> c{};
+    std::array<uint64_t, 5> d{};
 
 #if defined __clang__
-  // Following
-  // https://clang.llvm.org/docs/LanguageExtensions.html#extensions-for-loop-hint-optimizations
+    // Following
+    // https://clang.llvm.org/docs/LanguageExtensions.html#extensions-for-loop-hint-optimizations
 
 #pragma clang loop unroll(enable)
 #pragma clang loop vectorize(enable)
 #elif defined __GNUG__
-  // Following
-  // https://gcc.gnu.org/onlinedocs/gcc/Loop-Specific-Pragmas.html#Loop-Specific-Pragmas
+    // Following
+    // https://gcc.gnu.org/onlinedocs/gcc/Loop-Specific-Pragmas.html#Loop-Specific-Pragmas
 
 #pragma GCC unroll 5
 #endif
-  for (size_t i = 0; i < 25; i += 5) {
-    c[0] ^= state[i + 0];
-    c[1] ^= state[i + 1];
-    c[2] ^= state[i + 2];
-    c[3] ^= state[i + 3];
-    c[4] ^= state[i + 4];
-  }
+    for (size_t i = 0; i < 25; i += 5) {
+      c[0] ^= state[i + 0];
+      c[1] ^= state[i + 1];
+      c[2] ^= state[i + 2];
+      c[3] ^= state[i + 3];
+      c[4] ^= state[i + 4];
+    }
 
-  d[0] = c[4] ^ std::rotl(c[1], 1);
-  d[1] = c[0] ^ std::rotl(c[2], 1);
-  d[2] = c[1] ^ std::rotl(c[3], 1);
-  d[3] = c[2] ^ std::rotl(c[4], 1);
-  d[4] = c[3] ^ std::rotl(c[0], 1);
+    d[0] = c[4] ^ std::rotl(c[1], 1);
+    d[1] = c[0] ^ std::rotl(c[2], 1);
+    d[2] = c[1] ^ std::rotl(c[3], 1);
+    d[3] = c[2] ^ std::rotl(c[4], 1);
+    d[4] = c[3] ^ std::rotl(c[0], 1);
 
 #if defined __clang__
-  // Following
-  // https://clang.llvm.org/docs/LanguageExtensions.html#extensions-for-loop-hint-optimizations
+    // Following
+    // https://clang.llvm.org/docs/LanguageExtensions.html#extensions-for-loop-hint-optimizations
 
 #pragma clang loop unroll(enable)
 #pragma clang loop vectorize(enable)
 #elif defined __GNUG__
-  // Following
-  // https://gcc.gnu.org/onlinedocs/gcc/Loop-Specific-Pragmas.html#Loop-Specific-Pragmas
+    // Following
+    // https://gcc.gnu.org/onlinedocs/gcc/Loop-Specific-Pragmas.html#Loop-Specific-Pragmas
 
 #pragma GCC unroll 5
 #endif
-  for (size_t i = 0; i < 25; i += 5) {
-    state[i + 0] ^= d[0];
-    state[i + 1] ^= d[1];
-    state[i + 2] ^= d[2];
-    state[i + 3] ^= d[3];
-    state[i + 4] ^= d[4];
+    for (size_t i = 0; i < 25; i += 5) {
+      state[i + 0] ^= d[0];
+      state[i + 1] ^= d[1];
+      state[i + 2] ^= d[2];
+      state[i + 3] ^= d[3];
+      state[i + 4] ^= d[4];
+    }
   }
-}
 
-// Keccak-p[1600, 24] step mapping function ρ, see section 3.2.2 of SHA3
-// specification https://dx.doi.org/10.6028/NIST.FIPS.202
-inline static void
-rho(uint64_t* const state)
-{
+  // Keccak-p[1600, 24] step mapping function ρ, see section 3.2.2 of SHA3
+  // specification https://dx.doi.org/10.6028/NIST.FIPS.202
+  inline constexpr void rho()
+  {
 #if defined __clang__
-  // Following
-  // https://clang.llvm.org/docs/LanguageExtensions.html#extensions-for-loop-hint-optimizations
+    // Following
+    // https://clang.llvm.org/docs/LanguageExtensions.html#extensions-for-loop-hint-optimizations
 
 #pragma clang loop unroll(enable)
 #pragma clang loop vectorize(enable)
 #elif defined __GNUG__
-  // Following
-  // https://gcc.gnu.org/onlinedocs/gcc/Loop-Specific-Pragmas.html#Loop-Specific-Pragmas
+    // Following
+    // https://gcc.gnu.org/onlinedocs/gcc/Loop-Specific-Pragmas.html#Loop-Specific-Pragmas
 
 #pragma GCC unroll 25
 #endif
-  for (size_t i = 0; i < 25; i++) {
-    state[i] = std::rotl(state[i], ROT[i]);
+    for (size_t i = 0; i < 25; i++) {
+      state[i] = std::rotl(state[i], ROT[i]);
+    }
   }
-}
 
-// Keccak-p[1600, 24] step mapping function π, see section 3.2.3 of SHA3
-// specification https://dx.doi.org/10.6028/NIST.FIPS.202
-inline static void
-pi(const uint64_t* const __restrict istate, // input permutation state
-   uint64_t* const __restrict ostate        // output permutation state
-)
-{
+  // Keccak-p[1600, 24] step mapping function π, see section 3.2.3 of SHA3
+  // specification https://dx.doi.org/10.6028/NIST.FIPS.202
+  inline constexpr void pi()
+  {
+    std::array<uint64_t, LANE_CNT> tmp{};
+
 #if defined __clang__
-  // Following
-  // https://clang.llvm.org/docs/LanguageExtensions.html#extensions-for-loop-hint-optimizations
+    // Following
+    // https://clang.llvm.org/docs/LanguageExtensions.html#extensions-for-loop-hint-optimizations
 
 #pragma clang loop unroll(enable)
 #pragma clang loop vectorize(enable)
 #elif defined __GNUG__
-  // Following
-  // https://gcc.gnu.org/onlinedocs/gcc/Loop-Specific-Pragmas.html#Loop-Specific-Pragmas
+    // Following
+    // https://gcc.gnu.org/onlinedocs/gcc/Loop-Specific-Pragmas.html#Loop-Specific-Pragmas
 
 #pragma GCC unroll 25
 #endif
-  for (size_t i = 0; i < 25; i++) {
-    ostate[i] = istate[PERM[i]];
-  }
-}
+    for (size_t i = 0; i < 25; i++) {
+      tmp[i] = state[PERM[i]];
+    }
 
-// Keccak-p[1600, 24] step mapping function χ, see section 3.2.4 of SHA3
-// specification https://dx.doi.org/10.6028/NIST.FIPS.202
-inline static void
-chi(const uint64_t* const __restrict istate, // input permutation state
-    uint64_t* const __restrict ostate        // output permutation state
-)
-{
+    std::ranges::copy(tmp.begin(), tmp.end(), state.begin());
+  }
+
+  // Keccak-p[1600, 24] step mapping function χ, see section 3.2.4 of SHA3
+  // specification https://dx.doi.org/10.6028/NIST.FIPS.202
+  inline constexpr void chi()
+  {
+    std::array<uint64_t, LANE_CNT> tmp{};
+
 #if defined __clang__
-  // Following
-  // https://clang.llvm.org/docs/LanguageExtensions.html#extensions-for-loop-hint-optimizations
+    // Following
+    // https://clang.llvm.org/docs/LanguageExtensions.html#extensions-for-loop-hint-optimizations
 
 #pragma clang loop unroll(enable)
 #pragma clang loop vectorize(enable)
 #elif defined __GNUG__
-  // Following
-  // https://gcc.gnu.org/onlinedocs/gcc/Loop-Specific-Pragmas.html#Loop-Specific-Pragmas
+    // Following
+    // https://gcc.gnu.org/onlinedocs/gcc/Loop-Specific-Pragmas.html#Loop-Specific-Pragmas
 
 #pragma GCC unroll 5
 #endif
-  for (size_t i = 0; i < 5; i++) {
-    const size_t ix5 = i * 5;
+    for (size_t i = 0; i < 5; i++) {
+      const size_t ix5 = i * 5;
 
-    ostate[ix5 + 0] = istate[ix5 + 0] ^ (~istate[ix5 + 1] & istate[ix5 + 2]);
-    ostate[ix5 + 1] = istate[ix5 + 1] ^ (~istate[ix5 + 2] & istate[ix5 + 3]);
-    ostate[ix5 + 2] = istate[ix5 + 2] ^ (~istate[ix5 + 3] & istate[ix5 + 4]);
-    ostate[ix5 + 3] = istate[ix5 + 3] ^ (~istate[ix5 + 4] & istate[ix5 + 0]);
-    ostate[ix5 + 4] = istate[ix5 + 4] ^ (~istate[ix5 + 0] & istate[ix5 + 1]);
+      tmp[ix5 + 0] = state[ix5 + 0] ^ (~state[ix5 + 1] & state[ix5 + 2]);
+      tmp[ix5 + 1] = state[ix5 + 1] ^ (~state[ix5 + 2] & state[ix5 + 3]);
+      tmp[ix5 + 2] = state[ix5 + 2] ^ (~state[ix5 + 3] & state[ix5 + 4]);
+      tmp[ix5 + 3] = state[ix5 + 3] ^ (~state[ix5 + 4] & state[ix5 + 0]);
+      tmp[ix5 + 4] = state[ix5 + 4] ^ (~state[ix5 + 0] & state[ix5 + 1]);
+    }
+
+    std::ranges::copy(tmp.begin(), tmp.end(), state.begin());
   }
-}
 
-// Keccak-p[1600, 24] step mapping function ι, see section 3.2.5 of SHA3
-// specification https://dx.doi.org/10.6028/NIST.FIPS.202
-inline static void
-iota(uint64_t* const state, const size_t r_idx)
-{
-  state[0] ^= RC[r_idx];
-}
+  // Keccak-p[1600, 24] step mapping function ι, see section 3.2.5 of SHA3
+  // specification https://dx.doi.org/10.6028/NIST.FIPS.202
+  inline constexpr void iota(const uint64_t rc) { state[0] ^= rc; }
 
-// Keccak-p[1600, 24] round function, which applies all five
-// step mapping functions in order, updates state array
-//
-// See section 3.3 of https://dx.doi.org/10.6028/NIST.FIPS.202
-inline static void
-round(uint64_t* const state, const size_t r_idx)
-{
-  uint64_t tmp[25]{};
-
-  theta(state);
-  rho(state);
-  pi(state, tmp);
-  chi(tmp, state);
-  iota(state, r_idx);
-}
-
-// Keccak-p[1600, 24] permutation, applying 24 rounds of permutation
-// on state of dimension 5 x 5 x 64 ( = 1600 ) -bits, using algorithm 7 defined
-// in section 3.3 of SHA3 specification https://dx.doi.org/10.6028/NIST.FIPS.202
-inline void
-permute(uint64_t* const state)
-{
-  for (size_t i = 0; i < ROUNDS; i++) {
-    round(state, i);
+  // Keccak-p[1600, 24] round function, which applies all five
+  // step mapping functions in order, updates state array
+  //
+  // See section 3.3 of https://dx.doi.org/10.6028/NIST.FIPS.202
+  inline constexpr void round(const uint64_t rc)
+  {
+    theta();
+    rho();
+    pi();
+    chi();
+    iota(rc);
   }
-}
+
+public:
+  // Constructors
+  inline constexpr keccak_t() = default;
+  inline constexpr keccak_t(std::array<uint64_t, LANE_CNT>& words)
+  {
+    state = words;
+  }
+  inline constexpr keccak_t(std::array<uint64_t, LANE_CNT>&& words)
+  {
+    state = words;
+  }
+  inline constexpr keccak_t(const std::array<uint64_t, LANE_CNT>& words)
+  {
+    state = words;
+  }
+  inline constexpr keccak_t(const std::array<uint64_t, LANE_CNT>&& words)
+  {
+    state = words;
+  }
+
+  // Keccak-p[1600, 24] permutation, applying 24 rounds of permutation
+  // on state of dimension 5 x 5 x 64 ( = 1600 ) -bits, using algorithm 7
+  // defined in section 3.3 of SHA3 specification
+  // https://dx.doi.org/10.6028/NIST.FIPS.202
+  inline constexpr void permute()
+  {
+    for (size_t i = 0; i < ROUNDS; i++) {
+      round(RC[i]);
+    }
+  }
+
+  // Returns reference to 64 -bit row of Keccak-p[1600] permutation state, given
+  // idx ∈ [0, 25).
+  inline constexpr uint64_t& operator[](const size_t idx) { return state[idx]; }
+
+  // Returns const reference to 64 -bit row of Keccak-p[1600] permutation state,
+  // given idx ∈ [0, 25).
+  inline constexpr const uint64_t& operator[](const size_t idx) const
+  {
+    return state[idx];
+  }
+
+  // Returns 1600 -bit whole state of Keccak-p permutation.
+  inline constexpr std::array<uint64_t, LANE_CNT> reveal() const
+  {
+    return state;
+  }
+};
 
 }

--- a/include/keccak.hpp
+++ b/include/keccak.hpp
@@ -322,11 +322,14 @@ public:
     return state[idx];
   }
 
-  // Returns 1600 -bit whole state of Keccak-p permutation.
+  // Returns a copy of 1600 -bit whole state of Keccak-p permutation.
   inline constexpr std::array<uint64_t, LANE_CNT> reveal() const
   {
     return state;
   }
+
+  // Returns a reference to 1600 -bit whole state of Keccak-p permutation.
+  inline constexpr std::array<uint64_t, LANE_CNT>& reveal() { return state; }
 };
 
 }

--- a/include/sha3_224.hpp
+++ b/include/sha3_224.hpp
@@ -37,15 +37,15 @@ private:
 
 public:
   // Constructor
-  inline sha3_224_t() = default;
+  inline constexpr sha3_224_t() = default;
 
   // Given N(>=0) -bytes message as input, this routine can be invoked arbitrary
   // many times ( until the sponge is finalized ), each time absorbing arbitrary
   // many message bytes into RATE portion of the sponge.
-  inline void absorb(const uint8_t* const msg, const size_t mlen)
+  inline constexpr void absorb(std::span<const uint8_t> msg)
   {
     if (!finalized) {
-      sponge::absorb<RATE>(state, offset, msg, mlen);
+      sponge::absorb<RATE>(state, offset, msg);
     }
   }
 
@@ -53,7 +53,7 @@ public:
   // should be ready for squeezing message digest bytes. Once finalized, you
   // can't absorb any message bytes into sponge. After finalization, calling
   // this function again and again doesn't mutate anything.
-  inline void finalize()
+  inline constexpr void finalize()
   {
     if (!finalized) {
       sponge::finalize<DOM_SEP, DOM_SEP_BW, RATE>(state, offset);
@@ -64,11 +64,11 @@ public:
   // After sponge state is finalized, 28 message digest bytes can be squeezed by
   // calling this function. Once digest bytes are squeezed, calling this
   // function again and again returns nothing.
-  inline void digest(uint8_t* const md)
+  inline constexpr void digest(std::span<uint8_t, DIGEST_LEN> md)
   {
     if (finalized && !squeezed) {
       size_t squeezable = RATE / 8;
-      sponge::squeeze<RATE>(state, squeezable, md, DIGEST_LEN);
+      sponge::squeeze<RATE>(state, squeezable, md);
 
       squeezed = true;
     }
@@ -76,7 +76,7 @@ public:
 
   // Reset the internal state of the SHA3-224 hasher, now it can again be used
   // for another absorb->finalize->squeeze cycle.
-  inline void reset()
+  inline constexpr void reset()
   {
     state = {};
     offset = 0;

--- a/include/sha3_224.hpp
+++ b/include/sha3_224.hpp
@@ -76,7 +76,13 @@ public:
 
   // Reset the internal state of the SHA3-224 hasher, now it can again be used
   // for another absorb->finalize->squeeze cycle.
-  inline void reset() { std::memset(this, 0, sizeof(*this)); }
+  inline void reset()
+  {
+    state = {};
+    offset = 0;
+    finalized = false;
+    squeezed = false;
+  }
 };
 
 }

--- a/include/sha3_224.hpp
+++ b/include/sha3_224.hpp
@@ -27,17 +27,17 @@ constexpr size_t DOM_SEP_BW = 2;
 //
 // See SHA3 hash function definition in section 6.1 of SHA3 specification
 // https://dx.doi.org/10.6028/NIST.FIPS.202.
-struct sha3_224
+struct sha3_224_t
 {
 private:
-  uint64_t state[keccak::LANE_CNT]{};
+  keccak::keccak_t state{};
   size_t offset = 0;
   alignas(4) bool finalized = false;
   alignas(4) bool squeezed = false;
 
 public:
   // Constructor
-  inline sha3_224() = default;
+  inline sha3_224_t() = default;
 
   // Given N(>=0) -bytes message as input, this routine can be invoked arbitrary
   // many times ( until the sponge is finalized ), each time absorbing arbitrary

--- a/include/sha3_256.hpp
+++ b/include/sha3_256.hpp
@@ -27,17 +27,17 @@ constexpr size_t DOM_SEP_BW = 2;
 //
 // See SHA3 hash function definition in section 6.1 of SHA3 specification
 // https://dx.doi.org/10.6028/NIST.FIPS.202.
-struct sha3_256
+struct sha3_256_t
 {
 private:
-  uint64_t state[keccak::LANE_CNT]{};
+  keccak::keccak_t state{};
   size_t offset = 0;
   alignas(4) bool finalized = false;
   alignas(4) bool squeezed = false;
 
 public:
   // Constructor
-  inline sha3_256() = default;
+  inline sha3_256_t() = default;
 
   // Given N(>=0) -bytes message as input, this routine can be invoked arbitrary
   // many times ( until the sponge is finalized ), each time absorbing arbitrary

--- a/include/sha3_256.hpp
+++ b/include/sha3_256.hpp
@@ -37,15 +37,15 @@ private:
 
 public:
   // Constructor
-  inline sha3_256_t() = default;
+  inline constexpr sha3_256_t() = default;
 
   // Given N(>=0) -bytes message as input, this routine can be invoked arbitrary
   // many times ( until the sponge is finalized ), each time absorbing arbitrary
   // many message bytes into RATE portion of the sponge.
-  inline void absorb(const uint8_t* const msg, const size_t mlen)
+  inline constexpr void absorb(std::span<const uint8_t> msg)
   {
     if (!finalized) {
-      sponge::absorb<RATE>(state, offset, msg, mlen);
+      sponge::absorb<RATE>(state, offset, msg);
     }
   }
 
@@ -53,7 +53,7 @@ public:
   // should be ready for squeezing message digest bytes. Once finalized, you
   // can't absorb any message bytes into sponge. After finalization, calling
   // this function again and again doesn't mutate anything.
-  inline void finalize()
+  inline constexpr void finalize()
   {
     if (!finalized) {
       sponge::finalize<DOM_SEP, DOM_SEP_BW, RATE>(state, offset);
@@ -64,11 +64,11 @@ public:
   // After sponge state is finalized, 32 message digest bytes can be squeezed by
   // calling this function. Once digest bytes are squeezed, calling this
   // function again and again returns nothing.
-  inline void digest(uint8_t* const md)
+  inline constexpr void digest(std::span<uint8_t, DIGEST_LEN> md)
   {
     if (finalized && !squeezed) {
       size_t squeezable = RATE / 8;
-      sponge::squeeze<RATE>(state, squeezable, md, DIGEST_LEN);
+      sponge::squeeze<RATE>(state, squeezable, md);
 
       squeezed = true;
     }
@@ -76,7 +76,7 @@ public:
 
   // Reset the internal state of the SHA3-256 hasher, now it can again be used
   // for another absorb->finalize->squeeze cycle.
-  inline void reset()
+  inline constexpr void reset()
   {
     state = {};
     offset = 0;

--- a/include/sha3_256.hpp
+++ b/include/sha3_256.hpp
@@ -76,7 +76,13 @@ public:
 
   // Reset the internal state of the SHA3-256 hasher, now it can again be used
   // for another absorb->finalize->squeeze cycle.
-  inline void reset() { std::memset(this, 0, sizeof(*this)); }
+  inline void reset()
+  {
+    state = {};
+    offset = 0;
+    finalized = false;
+    squeezed = false;
+  }
 };
 
 }

--- a/include/sha3_384.hpp
+++ b/include/sha3_384.hpp
@@ -27,17 +27,17 @@ constexpr size_t DOM_SEP_BW = 2;
 //
 // See SHA3 hash function definition in section 6.1 of SHA3 specification
 // https://dx.doi.org/10.6028/NIST.FIPS.202.
-struct sha3_384
+struct sha3_384_t
 {
 private:
-  uint64_t state[keccak::LANE_CNT]{};
+  keccak::keccak_t state{};
   size_t offset = 0;
   alignas(4) bool finalized = false;
   alignas(4) bool squeezed = false;
 
 public:
   // Constructor
-  inline sha3_384() = default;
+  inline sha3_384_t() = default;
 
   // Given N(>=0) -bytes message as input, this routine can be invoked arbitrary
   // many times ( until the sponge is finalized ), each time absorbing arbitrary

--- a/include/sha3_384.hpp
+++ b/include/sha3_384.hpp
@@ -37,15 +37,15 @@ private:
 
 public:
   // Constructor
-  inline sha3_384_t() = default;
+  inline constexpr sha3_384_t() = default;
 
   // Given N(>=0) -bytes message as input, this routine can be invoked arbitrary
   // many times ( until the sponge is finalized ), each time absorbing arbitrary
   // many message bytes into RATE portion of the sponge.
-  inline void absorb(const uint8_t* const msg, const size_t mlen)
+  inline constexpr void absorb(std::span<const uint8_t> msg)
   {
     if (!finalized) {
-      sponge::absorb<RATE>(state, offset, msg, mlen);
+      sponge::absorb<RATE>(state, offset, msg);
     }
   }
 
@@ -53,7 +53,7 @@ public:
   // should be ready for squeezing message digest bytes. Once finalized, you
   // can't absorb any message bytes into sponge. After finalization, calling
   // this function again and again doesn't mutate anything.
-  inline void finalize()
+  inline constexpr void finalize()
   {
     if (!finalized) {
       sponge::finalize<DOM_SEP, DOM_SEP_BW, RATE>(state, offset);
@@ -64,11 +64,11 @@ public:
   // After sponge state is finalized, 48 message digest bytes can be squeezed by
   // calling this function. Once digest bytes are squeezed, calling this
   // function again and again returns nothing.
-  inline void digest(uint8_t* const md)
+  inline constexpr void digest(std::span<uint8_t, DIGEST_LEN> md)
   {
     if (finalized && !squeezed) {
       size_t squeezable = RATE / 8;
-      sponge::squeeze<RATE>(state, squeezable, md, DIGEST_LEN);
+      sponge::squeeze<RATE>(state, squeezable, md);
 
       squeezed = true;
     }
@@ -76,7 +76,7 @@ public:
 
   // Reset the internal state of the SHA3-384 hasher, now it can again be used
   // for another absorb->finalize->squeeze cycle.
-  inline void reset()
+  inline constexpr void reset()
   {
     state = {};
     offset = 0;

--- a/include/sha3_384.hpp
+++ b/include/sha3_384.hpp
@@ -76,7 +76,13 @@ public:
 
   // Reset the internal state of the SHA3-384 hasher, now it can again be used
   // for another absorb->finalize->squeeze cycle.
-  inline void reset() { std::memset(this, 0, sizeof(*this)); }
+  inline void reset()
+  {
+    state = {};
+    offset = 0;
+    finalized = false;
+    squeezed = false;
+  }
 };
 
 }

--- a/include/sha3_512.hpp
+++ b/include/sha3_512.hpp
@@ -76,7 +76,13 @@ public:
 
   // Reset the internal state of the SHA3-512 hasher, now it can again be used
   // for another absorb->finalize->squeeze cycle.
-  inline void reset() { std::memset(this, 0, sizeof(*this)); }
+  inline void reset()
+  {
+    state = {};
+    offset = 0;
+    finalized = false;
+    squeezed = false;
+  }
 };
 
 }

--- a/include/sha3_512.hpp
+++ b/include/sha3_512.hpp
@@ -37,15 +37,15 @@ private:
 
 public:
   // Constructor
-  inline sha3_512_t() = default;
+  inline constexpr sha3_512_t() = default;
 
   // Given N(>=0) -bytes message as input, this routine can be invoked arbitrary
   // many times ( until the sponge is finalized ), each time absorbing arbitrary
   // many message bytes into RATE portion of the sponge.
-  inline void absorb(const uint8_t* const msg, const size_t mlen)
+  inline constexpr void absorb(std::span<const uint8_t> msg)
   {
     if (!finalized) {
-      sponge::absorb<RATE>(state, offset, msg, mlen);
+      sponge::absorb<RATE>(state, offset, msg);
     }
   }
 
@@ -53,7 +53,7 @@ public:
   // should be ready for squeezing message digest bytes. Once finalized, you
   // can't absorb any message bytes into sponge. After finalization, calling
   // this function again and again doesn't mutate anything.
-  inline void finalize()
+  inline constexpr void finalize()
   {
     if (!finalized) {
       sponge::finalize<DOM_SEP, DOM_SEP_BW, RATE>(state, offset);
@@ -64,11 +64,11 @@ public:
   // After sponge state is finalized, 64 message digest bytes can be squeezed by
   // calling this function. Once digest bytes are squeezed, calling this
   // function again and again returns nothing.
-  inline void digest(uint8_t* const md)
+  inline constexpr void digest(std::span<uint8_t, DIGEST_LEN> md)
   {
     if (finalized && !squeezed) {
       size_t squeezable = RATE / 8;
-      sponge::squeeze<RATE>(state, squeezable, md, DIGEST_LEN);
+      sponge::squeeze<RATE>(state, squeezable, md);
 
       squeezed = true;
     }
@@ -76,7 +76,7 @@ public:
 
   // Reset the internal state of the SHA3-512 hasher, now it can again be used
   // for another absorb->finalize->squeeze cycle.
-  inline void reset()
+  inline constexpr void reset()
   {
     state = {};
     offset = 0;

--- a/include/sha3_512.hpp
+++ b/include/sha3_512.hpp
@@ -27,17 +27,17 @@ constexpr size_t DOM_SEP_BW = 2;
 //
 // See SHA3 hash function definition in section 6.1 of SHA3 specification
 // https://dx.doi.org/10.6028/NIST.FIPS.202.
-struct sha3_512
+struct sha3_512_t
 {
 private:
-  uint64_t state[keccak::LANE_CNT]{};
+  keccak::keccak_t state{};
   size_t offset = 0;
   alignas(4) bool finalized = false;
   alignas(4) bool squeezed = false;
 
 public:
   // Constructor
-  inline sha3_512() = default;
+  inline sha3_512_t() = default;
 
   // Given N(>=0) -bytes message as input, this routine can be invoked arbitrary
   // many times ( until the sponge is finalized ), each time absorbing arbitrary

--- a/include/shake128.hpp
+++ b/include/shake128.hpp
@@ -73,7 +73,13 @@ public:
 
   // Reset the internal state of the Shake128-Xof hasher, now it can again be
   // used for another absorb->finalize->squeeze cycle.
-  inline void reset() { std::memset(this, 0, sizeof(*this)); }
+  inline void reset()
+  {
+    state = {};
+    offset = 0;
+    finalized = false;
+    squeezable = 0;
+  }
 };
 
 }

--- a/include/shake128.hpp
+++ b/include/shake128.hpp
@@ -29,7 +29,7 @@ private:
   size_t squeezable = 0;
 
 public:
-  inline shake128_t() = default;
+  inline constexpr shake128_t() = default;
 
   // Given N -many bytes input message, this routine consumes those into
   // keccak[256] sponge state.
@@ -38,10 +38,10 @@ public:
   // arbitrary bytes of input message, until keccak[256] state is finalized ( by
   // calling routine with similar name ). Once the sponge is finalized, it can't
   // absorb any more message bytes.
-  inline void absorb(const uint8_t* const msg, const size_t mlen)
+  inline constexpr void absorb(std::span<const uint8_t> msg)
   {
     if (!finalized) {
-      sponge::absorb<RATE>(state, offset, msg, mlen);
+      sponge::absorb<RATE>(state, offset, msg);
     }
   }
 
@@ -52,7 +52,7 @@ public:
   // same SHAKE128 object, doesn't do anything. After finalization, one might
   // intend to read arbitrary many bytes by squeezing sponge, which is done by
   // calling read() function, as many times required.
-  inline void finalize()
+  inline constexpr void finalize()
   {
     if (!finalized) {
       sponge::finalize<DOM_SEP, DOM_SEP_BW, RATE>(state, offset);
@@ -64,16 +64,16 @@ public:
 
   // After sponge state is finalized, arbitrary many output bytes can be
   // squeezed by calling this function any number of times required.
-  inline void squeeze(uint8_t* const dig, const size_t dlen)
+  inline constexpr void squeeze(std::span<uint8_t> dig)
   {
     if (finalized) {
-      sponge::squeeze<RATE>(state, squeezable, dig, dlen);
+      sponge::squeeze<RATE>(state, squeezable, dig);
     }
   }
 
   // Reset the internal state of the Shake128-Xof hasher, now it can again be
   // used for another absorb->finalize->squeeze cycle.
-  inline void reset()
+  inline constexpr void reset()
   {
     state = {};
     offset = 0;

--- a/include/shake128.hpp
+++ b/include/shake128.hpp
@@ -20,16 +20,16 @@ constexpr size_t DOM_SEP_BW = 4;
 //
 // See SHA3 extendable output function definition in section 6.2 of SHA3
 // specification https://dx.doi.org/10.6028/NIST.FIPS.202
-struct shake128
+struct shake128_t
 {
 private:
-  uint64_t state[keccak::LANE_CNT]{};
+  keccak::keccak_t state{};
   size_t offset = 0;
   alignas(4) bool finalized = false; // all message bytes absorbed ?
   size_t squeezable = 0;
 
 public:
-  inline shake128() = default;
+  inline shake128_t() = default;
 
   // Given N -many bytes input message, this routine consumes those into
   // keccak[256] sponge state.

--- a/include/shake256.hpp
+++ b/include/shake256.hpp
@@ -20,16 +20,16 @@ constexpr size_t DOM_SEP_BW = 4;
 //
 // See SHA3 extendable output function definition in section 6.2 of SHA3
 // specification https://dx.doi.org/10.6028/NIST.FIPS.202
-struct shake256
+struct shake256_t
 {
 private:
-  uint64_t state[keccak::LANE_CNT]{};
+  keccak::keccak_t state{};
   size_t offset = 0;
   alignas(4) bool finalized = false; // all message bytes absorbed ?
   size_t squeezable = 0;
 
 public:
-  inline shake256() = default;
+  inline shake256_t() = default;
 
   // Given N -many bytes input message, this routine consumes those into
   // keccak[512] sponge state.

--- a/include/shake256.hpp
+++ b/include/shake256.hpp
@@ -73,7 +73,13 @@ public:
 
   // Reset the internal state of the Shake256-Xof hasher, now it can again be
   // used for another absorb->finalize->squeeze cycle.
-  inline void reset() { std::memset(this, 0, sizeof(*this)); }
+  inline void reset()
+  {
+    state = {};
+    offset = 0;
+    finalized = false;
+    squeezable = 0;
+  }
 };
 
 }

--- a/include/shake256.hpp
+++ b/include/shake256.hpp
@@ -29,7 +29,7 @@ private:
   size_t squeezable = 0;
 
 public:
-  inline shake256_t() = default;
+  inline constexpr shake256_t() = default;
 
   // Given N -many bytes input message, this routine consumes those into
   // keccak[512] sponge state.
@@ -38,10 +38,10 @@ public:
   // arbitrary bytes of input message, until keccak[512] state is finalized ( by
   // calling routine with similar name ). Once the sponge is finalized, it can't
   // absorb any more message bytes.
-  inline void absorb(const uint8_t* const msg, const size_t mlen)
+  inline constexpr void absorb(std::span<const uint8_t> msg)
   {
     if (!finalized) {
-      sponge::absorb<RATE>(state, offset, msg, mlen);
+      sponge::absorb<RATE>(state, offset, msg);
     }
   }
 
@@ -52,7 +52,7 @@ public:
   // same SHAKE256 object, doesn't do anything. After finalization, one might
   // intend to read arbitrary many bytes by squeezing sponge, which is done by
   // calling read() function, as many times required.
-  inline void finalize()
+  inline constexpr void finalize()
   {
     if (!finalized) {
       sponge::finalize<DOM_SEP, DOM_SEP_BW, RATE>(state, offset);
@@ -64,16 +64,16 @@ public:
 
   // After sponge state is finalized, arbitrary many output bytes can be
   // squeezed by calling this function any number of times required.
-  inline void squeeze(uint8_t* const dig, const size_t dlen)
+  inline constexpr void squeeze(std::span<uint8_t> dig)
   {
     if (finalized) {
-      sponge::squeeze<RATE>(state, squeezable, dig, dlen);
+      sponge::squeeze<RATE>(state, squeezable, dig);
     }
   }
 
   // Reset the internal state of the Shake256-Xof hasher, now it can again be
   // used for another absorb->finalize->squeeze cycle.
-  inline void reset()
+  inline constexpr void reset()
   {
     state = {};
     offset = 0;

--- a/include/sponge.hpp
+++ b/include/sponge.hpp
@@ -176,7 +176,7 @@ squeeze(keccak::keccak_t& state, size_t& squeezable, std::span<uint8_t> out)
   auto _blk_bytes = std::span(blk_bytes);
 
   auto swords = std::span(state.reveal());
-  auto _swords = swords.subspan<0, rwords>();
+  auto _swords = swords.template subspan<0, rwords>();
 
   const size_t olen = out.size();
   size_t off = 0;

--- a/include/sponge.hpp
+++ b/include/sponge.hpp
@@ -169,7 +169,8 @@ template<const size_t rate>
 static inline constexpr void
 squeeze(keccak::keccak_t& state, size_t& squeezable, std::span<uint8_t> out)
 {
-  constexpr size_t rbytes = rate >> 3; // # -of bytes
+  constexpr size_t rbytes = rate >> 3;   // # -of bytes
+  constexpr size_t rwords = rbytes >> 3; // # -of 64 -bit words
 
   std::array<uint8_t, rbytes> blk_bytes{};
   auto _blk_bytes = std::span(blk_bytes);
@@ -181,7 +182,11 @@ squeeze(keccak::keccak_t& state, size_t& squeezable, std::span<uint8_t> out)
     const size_t read = std::min(squeezable, olen - off);
     const size_t soff = rbytes - squeezable;
 
-    sha3_utils::u64_words_to_le_bytes<rate>(state.reveal(), _blk_bytes);
+    auto st = state.reveal();
+    auto _st = std::span(st);
+    auto __st = _st.subspan<0, rwords>();
+
+    sha3_utils::u64_words_to_le_bytes<rate>(__st, _blk_bytes);
 
     auto _blk = _blk_bytes.subspan(soff, read);
     auto _out = out.subspan(off, read);

--- a/include/sponge.hpp
+++ b/include/sponge.hpp
@@ -175,6 +175,9 @@ squeeze(keccak::keccak_t& state, size_t& squeezable, std::span<uint8_t> out)
   std::array<uint8_t, rbytes> blk_bytes{};
   auto _blk_bytes = std::span(blk_bytes);
 
+  auto swords = std::span(state.reveal());
+  auto _swords = swords.subspan<0, rwords>();
+
   const size_t olen = out.size();
   size_t off = 0;
 
@@ -182,11 +185,7 @@ squeeze(keccak::keccak_t& state, size_t& squeezable, std::span<uint8_t> out)
     const size_t read = std::min(squeezable, olen - off);
     const size_t soff = rbytes - squeezable;
 
-    auto st = state.reveal();
-    auto _st = std::span(st);
-    auto __st = _st.subspan<0, rwords>();
-
-    sha3_utils::u64_words_to_le_bytes<rate>(__st, _blk_bytes);
+    sha3_utils::u64_words_to_le_bytes<rate>(_swords, _blk_bytes);
 
     auto _blk = _blk_bytes.subspan(soff, read);
     auto _out = out.subspan(off, read);

--- a/include/sponge.hpp
+++ b/include/sponge.hpp
@@ -5,15 +5,16 @@
 #include <array>
 #include <bit>
 #include <cstring>
+#include <span>
 
 // Keccak family of sponge functions
 namespace sponge {
 
 // Compile-time check to ensure that domain separator can only be 2/ 4 -bits
-// wide
+// wide.
 //
 // When used in context of extendable output functions ( SHAKE{128, 256} )
-// domain separator bits are 4 -bit wide
+// domain separator bits are 4 -bit wide.
 //
 // See section 6.{1, 2} of SHA3 specification
 // https://dx.doi.org/10.6028/NIST.FIPS.202
@@ -38,7 +39,7 @@ check_domain_separator(const size_t dom_sep_bit_len)
 template<const uint8_t domain_separator,
          const size_t ds_bits,
          const size_t rate>
-static inline std::array<uint8_t, rate / 8>
+static inline constexpr std::array<uint8_t, rate / 8>
 pad10x1(const size_t offset)
   requires(check_domain_separator(ds_bits))
 {
@@ -58,66 +59,58 @@ pad10x1(const size_t offset)
 // are already consumed into rate portion of the state.
 //
 // - `rate` portion of sponge will have bitwidth of 1600 - c.
-// - `offset` must ∈ [0, `rbytes`)
+// - `offset` must ∈ [0, `rbytes`).
 //
 // This function implementation collects inspiration from
 // https://github.com/itzmeanjan/turboshake/blob/e1a6b950/src/sponge.rs#L4-L56
 template<const size_t rate>
-static inline void
-absorb(keccak::keccak_t& state,
-       size_t& offset,
-       const uint8_t* const __restrict msg,
-       const size_t mlen)
+static inline constexpr void
+absorb(keccak::keccak_t& state, size_t& offset, std::span<const uint8_t> msg)
 {
   constexpr size_t rbytes = rate >> 3;   // # -of bytes
   constexpr size_t rwords = rbytes >> 3; // # -of 64 -bit words
 
-  uint8_t blk_bytes[rbytes]{};
-  uint64_t blk_words[rwords]{};
+  std::array<uint8_t, rbytes> blk_bytes{};
+  std::array<uint64_t, rwords> blk_words{};
 
+  auto _blk_bytes = std::span(blk_bytes);
+  auto _blk_words = std::span(blk_words);
+
+  const size_t mlen = msg.size();
   const size_t blk_cnt = (offset + mlen) / rbytes;
+
   size_t moff = 0;
 
   for (size_t i = 0; i < blk_cnt; i++) {
-    std::memcpy(blk_bytes + offset, msg + moff, rbytes - offset);
+    const size_t readable = rbytes - offset;
 
-    if constexpr (std::endian::native == std::endian::little) {
-      auto words = reinterpret_cast<const uint64_t*>(blk_bytes);
+    auto _msg = msg.subspan(moff, readable);
+    auto _blk = _blk_bytes.subspan(offset, readable);
 
-      for (size_t j = 0; j < rwords; j++) {
-        state[j] ^= words[j];
-      }
-    } else {
-      sha3_utils::bytes_to_le_words<rate>(blk_bytes, blk_words);
+    std::ranges::copy(_msg.begin(), _msg.end(), _blk.begin());
+    sha3_utils::le_bytes_to_u64_words<rate>(_blk_bytes, _blk_words);
 
-      for (size_t j = 0; j < rwords; j++) {
-        state[j] ^= blk_words[j];
-      }
+    for (size_t j = 0; j < rwords; j++) {
+      state[j] ^= _blk_words[j];
     }
 
     state.permute();
 
-    moff += (rbytes - offset);
+    moff += readable;
     offset = 0;
   }
 
   const size_t rm_bytes = mlen - moff;
 
-  std::memset(blk_bytes, 0, rbytes);
-  std::memcpy(blk_bytes + offset, msg + moff, rm_bytes);
+  auto _msg = msg.subspan(moff, rm_bytes);
+  auto _blk = _blk_bytes.subspan(offset, rm_bytes);
 
-  if constexpr (std::endian::native == std::endian::little) {
-    auto words = reinterpret_cast<const uint64_t*>(blk_bytes);
+  blk_bytes.fill(0x00);
+  std::ranges::copy(_msg.begin(), _msg.end(), _blk.begin());
+  sha3_utils::le_bytes_to_u64_words<rate>(_blk_bytes, _blk_words);
 
-    for (size_t j = 0; j < rwords; j++) {
-      state[j] ^= words[j];
-    }
-  } else {
-    sha3_utils::bytes_to_le_words<rate>(blk_bytes, blk_words);
-
-    for (size_t j = 0; j < rwords; j++) {
-      state[j] ^= blk_words[j];
-    }
+  for (size_t j = 0; j < rwords; j++) {
+    state[j] ^= _blk_words[j];
   }
 
   offset += rm_bytes;

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -90,31 +90,18 @@ u64_to_le_bytes(uint64_t word, std::span<uint8_t> bytes)
   bytes[7] = static_cast<uint8_t>(word >> 56);
 }
 
-// Given an array of uint64_t words, holding rate/ 8 -many bytes, this routine
-// can be used for interpreting words as little-endian bytes.
+// Given an array of rate/64 -many 64 -bit unsigned integer words, this routine
+// can be used for interpreting words in little-endian byte-order, computing
+// rate/8 -many bytes output.
 template<const size_t rate>
-static inline void
-words_to_le_bytes(const uint64_t* const __restrict words,
-                  uint8_t* const __restrict bytes)
+static inline constexpr void
+u64_words_to_le_bytes(std::span<const uint64_t, rate / 64> words,
+                      std::span<uint8_t, rate / 8> bytes)
 {
-  constexpr size_t rbytes = rate >> 3;   // # -of bytes
-  constexpr size_t rwords = rbytes >> 3; // # -of 64 -bit words
-
-  if constexpr (std::endian::native == std::endian::little) {
-    std::memcpy(bytes, words, rbytes);
-  } else {
-    for (size_t i = 0; i < rwords; i++) {
-      const size_t boff = i * 8;
-
-      bytes[boff + 0] = static_cast<uint8_t>(words[i] >> 0);
-      bytes[boff + 1] = static_cast<uint8_t>(words[i] >> 8);
-      bytes[boff + 2] = static_cast<uint8_t>(words[i] >> 16);
-      bytes[boff + 3] = static_cast<uint8_t>(words[i] >> 24);
-      bytes[boff + 4] = static_cast<uint8_t>(words[i] >> 32);
-      bytes[boff + 5] = static_cast<uint8_t>(words[i] >> 40);
-      bytes[boff + 6] = static_cast<uint8_t>(words[i] >> 48);
-      bytes[boff + 7] = static_cast<uint8_t>(words[i] >> 56);
-    }
+  size_t off = 0;
+  while (off < words.size()) {
+    u64_to_le_bytes(words[off], bytes.subspan(off * 8, 8));
+    off++;
   }
 }
 

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -61,26 +61,13 @@ le_bytes_to_u64(std::span<const uint8_t> bytes)
 // unsigned interger ) s.t. bytes in a word are placed in little-endian order.
 template<const size_t rate>
 static inline constexpr void
-bytes_to_le_words(std::span<const uint8_t, rate / 8>,
-                  std::span<uint64_t, rate / 64> words)
+le_bytes_to_u64_words(std::span<const uint8_t, rate / 8> bytes,
+                      std::span<uint64_t, rate / 64> words)
 {
-  constexpr size_t rbytes = rate >> 3;   // # -of bytes
-  constexpr size_t rwords = rbytes >> 3; // # -of 64 -bit words
-
-  if constexpr (std::endian::native == std::endian::little) {
-    std::memcpy(words, bytes, rbytes);
-  } else {
-    for (size_t j = 0; j < rwords; j++) {
-      const size_t boff = j << 3;
-      words[j] = (static_cast<uint64_t>(bytes[boff + 7]) << 56) |
-                 (static_cast<uint64_t>(bytes[boff + 6]) << 48) |
-                 (static_cast<uint64_t>(bytes[boff + 5]) << 40) |
-                 (static_cast<uint64_t>(bytes[boff + 4]) << 32) |
-                 (static_cast<uint64_t>(bytes[boff + 3]) << 24) |
-                 (static_cast<uint64_t>(bytes[boff + 2]) << 16) |
-                 (static_cast<uint64_t>(bytes[boff + 1]) << 8) |
-                 (static_cast<uint64_t>(bytes[boff + 0]) << 0);
-    }
+  size_t off = 0;
+  while (off < bytes.size()) {
+    words[off / 8] = le_bytes_to_u64(bytes.subspan(off, 8));
+    off += 8;
   }
 }
 

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -108,13 +108,14 @@ u64_words_to_le_bytes(std::span<const uint64_t, rate / 64> words,
 // Generates N -many random values of type T | N >= 0
 template<typename T>
 static inline void
-random_data(T* const data, const size_t len)
+random_data(std::span<T> data)
   requires(std::is_unsigned_v<T>)
 {
   std::random_device rd;
   std::mt19937_64 gen(rd());
   std::uniform_int_distribution<T> dis;
 
+  const size_t len = data.size();
   for (size_t i = 0; i < len; i++) {
     data[i] = dis(gen);
   }

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -35,6 +35,27 @@ bswap(const uint64_t a)
 #endif
 }
 
+// Given a byte array of length 8, this routine can be used for interpreting
+// those 8 -bytes in little-endian order, as a 64 -bit unsigned integer.
+static inline constexpr uint64_t
+le_bytes_to_u64(std::span<const uint8_t> bytes)
+{
+  const uint64_t word = (static_cast<uint64_t>(bytes[7]) << 56) |
+                        (static_cast<uint64_t>(bytes[6]) << 48) |
+                        (static_cast<uint64_t>(bytes[5]) << 40) |
+                        (static_cast<uint64_t>(bytes[4]) << 32) |
+                        (static_cast<uint64_t>(bytes[3]) << 24) |
+                        (static_cast<uint64_t>(bytes[2]) << 16) |
+                        (static_cast<uint64_t>(bytes[1]) << 8) |
+                        (static_cast<uint64_t>(bytes[0]) << 0);
+
+  if constexpr (std::endian::native == std::endian::big) {
+    return bswap(word);
+  } else {
+    return word;
+  }
+}
+
 // Given a byte array holding rate/8 -many bytes, this routine can be invoked
 // for interpreting those bytes as rate/ 64 -many words ( each word is 64 -bit
 // unsigned interger ) s.t. bytes in a word are placed in little-endian order.

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -71,6 +71,25 @@ le_bytes_to_u64_words(std::span<const uint8_t, rate / 8> bytes,
   }
 }
 
+// Given a 64 -bit unsigned integer as input, this routine can be used for
+// interpreting those 8 -bytes in little-endian byte order.
+static inline constexpr void
+u64_to_le_bytes(uint64_t word, std::span<uint8_t> bytes)
+{
+  if constexpr (std::endian::native == std::endian::big) {
+    word = bswap(word);
+  }
+
+  bytes[0] = static_cast<uint8_t>(word >> 0);
+  bytes[1] = static_cast<uint8_t>(word >> 8);
+  bytes[2] = static_cast<uint8_t>(word >> 16);
+  bytes[3] = static_cast<uint8_t>(word >> 24);
+  bytes[4] = static_cast<uint8_t>(word >> 32);
+  bytes[5] = static_cast<uint8_t>(word >> 40);
+  bytes[6] = static_cast<uint8_t>(word >> 48);
+  bytes[7] = static_cast<uint8_t>(word >> 56);
+}
+
 // Given an array of uint64_t words, holding rate/ 8 -many bytes, this routine
 // can be used for interpreting words as little-endian bytes.
 template<const size_t rate>

--- a/tests/test_sha3_224.cpp
+++ b/tests/test_sha3_224.cpp
@@ -16,7 +16,7 @@ TEST(Sha3Hashing, Sha3_224IncrementalAbsorption)
 
     sha3_utils::random_data(msg.data(), msg.size());
 
-    sha3_224::sha3_224 hasher;
+    sha3_224::sha3_224_t hasher;
 
     // Oneshot Hashing
     hasher.absorb(msg.data(), msg.size());
@@ -73,7 +73,7 @@ TEST(Sha3Hashing, Sha3_224KnownAnswerTests)
 
       std::vector<uint8_t> digest(sha3_224::DIGEST_LEN);
 
-      sha3_224::sha3_224 hasher;
+      sha3_224::sha3_224_t hasher;
 
       hasher.absorb(msg.data(), msg.size());
       hasher.finalize();

--- a/tests/test_sha3_224.cpp
+++ b/tests/test_sha3_224.cpp
@@ -5,6 +5,42 @@
 #include <gtest/gtest.h>
 #include <vector>
 
+// Eval SHA3-224 hash on statically defined input message during
+// compilation-time.
+constexpr std::array<uint8_t, sha3_224::DIGEST_LEN>
+eval_sha3_224()
+{
+  // Statically defined input.
+  std::array<uint8_t, sha3_224::DIGEST_LEN * 2> data{};
+  std::iota(data.begin(), data.end(), 0);
+
+  // To be computed output.
+  std::array<uint8_t, sha3_224::DIGEST_LEN> md{};
+
+  sha3_224::sha3_224_t hasher;
+  hasher.absorb(data);
+  hasher.finalize();
+  hasher.digest(md);
+
+  return md;
+}
+
+// Ensure that SHA3-224 implementation is compile-time evaluable.
+TEST(Sha3Hashing, CompileTimeEvalSha3_224)
+{
+  // Input  =
+  // 000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f3031323334353637
+  // Output = fc95d44e806cbbd484e379882238f555fda923878c443abe4ce4cdd6
+
+  constexpr auto md = eval_sha3_224();
+  static_assert(md ==
+                  std::array<uint8_t, sha3_224::DIGEST_LEN>{
+                    252, 149, 212, 78,  128, 108, 187, 212, 132, 227,
+                    121, 136, 34,  56,  245, 85,  253, 169, 35,  135,
+                    140, 68,  58,  190, 76,  228, 205, 214 },
+                "Must be able to compute Sha3-224 hash during compile-time !");
+}
+
 // Test that absorbing same input message bytes using both incremental and
 // one-shot hashing, should yield same output bytes, for SHA3-224 hasher.
 TEST(Sha3Hashing, Sha3_224IncrementalAbsorption)

--- a/tests/test_sha3_224.cpp
+++ b/tests/test_sha3_224.cpp
@@ -14,14 +14,18 @@ TEST(Sha3Hashing, Sha3_224IncrementalAbsorption)
     std::vector<uint8_t> out0(sha3_224::DIGEST_LEN);
     std::vector<uint8_t> out1(sha3_224::DIGEST_LEN);
 
-    sha3_utils::random_data(msg.data(), msg.size());
+    auto _msg = std::span(msg);
+    auto _out0 = std::span<uint8_t, sha3_224::DIGEST_LEN>(out0);
+    auto _out1 = std::span<uint8_t, sha3_224::DIGEST_LEN>(out1);
+
+    sha3_utils::random_data(_msg);
 
     sha3_224::sha3_224_t hasher;
 
     // Oneshot Hashing
-    hasher.absorb(msg.data(), msg.size());
+    hasher.absorb(_msg);
     hasher.finalize();
-    hasher.digest(out0.data());
+    hasher.digest(_out0);
 
     hasher.reset();
 
@@ -31,14 +35,14 @@ TEST(Sha3Hashing, Sha3_224IncrementalAbsorption)
       // because we don't want to be stuck in an infinite loop if msg[off] = 0 !
       auto elen = std::min<size_t>(std::max<uint8_t>(msg[off], 1), mlen - off);
 
-      hasher.absorb(msg.data() + off, elen);
+      hasher.absorb(_msg.subspan(off, elen));
       off += elen;
     }
 
     hasher.finalize();
-    hasher.digest(out1.data());
+    hasher.digest(_out1);
 
-    ASSERT_TRUE(std::ranges::equal(out0, out1));
+    EXPECT_EQ(out0, out1);
   }
 }
 
@@ -72,14 +76,15 @@ TEST(Sha3Hashing, Sha3_224KnownAnswerTests)
       auto md = sha3_utils::from_hex(md2);
 
       std::vector<uint8_t> digest(sha3_224::DIGEST_LEN);
+      auto _digest = std::span<uint8_t, sha3_224::DIGEST_LEN>(digest);
 
       sha3_224::sha3_224_t hasher;
 
-      hasher.absorb(msg.data(), msg.size());
+      hasher.absorb(msg);
       hasher.finalize();
-      hasher.digest(digest.data());
+      hasher.digest(_digest);
 
-      ASSERT_TRUE(std::ranges::equal(digest, md));
+      EXPECT_EQ(digest, md);
 
       std::string empty_line;
       std::getline(file, empty_line);

--- a/tests/test_sha3_256.cpp
+++ b/tests/test_sha3_256.cpp
@@ -14,14 +14,18 @@ TEST(Sha3Hashing, Sha3_256IncrementalAbsorption)
     std::vector<uint8_t> out0(sha3_256::DIGEST_LEN);
     std::vector<uint8_t> out1(sha3_256::DIGEST_LEN);
 
-    sha3_utils::random_data(msg.data(), msg.size());
+    auto _msg = std::span(msg);
+    auto _out0 = std::span<uint8_t, sha3_256::DIGEST_LEN>(out0);
+    auto _out1 = std::span<uint8_t, sha3_256::DIGEST_LEN>(out1);
+
+    sha3_utils::random_data(_msg);
 
     sha3_256::sha3_256_t hasher;
 
     // Oneshot Hashing
-    hasher.absorb(msg.data(), msg.size());
+    hasher.absorb(_msg);
     hasher.finalize();
-    hasher.digest(out0.data());
+    hasher.digest(_out0);
 
     hasher.reset();
 
@@ -31,14 +35,14 @@ TEST(Sha3Hashing, Sha3_256IncrementalAbsorption)
       // because we don't want to be stuck in an infinite loop if msg[off] = 0 !
       auto elen = std::min<size_t>(std::max<uint8_t>(msg[off], 1), mlen - off);
 
-      hasher.absorb(msg.data() + off, elen);
+      hasher.absorb(_msg.subspan(off, elen));
       off += elen;
     }
 
     hasher.finalize();
-    hasher.digest(out1.data());
+    hasher.digest(_out1);
 
-    ASSERT_TRUE(std::ranges::equal(out0, out1));
+    EXPECT_EQ(out0, out1);
   }
 }
 
@@ -72,14 +76,15 @@ TEST(Sha3Hashing, Sha3_256KnownAnswerTests)
       auto md = sha3_utils::from_hex(md2);
 
       std::vector<uint8_t> digest(sha3_256::DIGEST_LEN);
+      auto _digest = std::span<uint8_t, sha3_256::DIGEST_LEN>(digest);
 
       sha3_256::sha3_256_t hasher;
 
-      hasher.absorb(msg.data(), msg.size());
+      hasher.absorb(msg);
       hasher.finalize();
-      hasher.digest(digest.data());
+      hasher.digest(_digest);
 
-      ASSERT_TRUE(std::ranges::equal(digest, md));
+      EXPECT_EQ(digest, md);
 
       std::string empty_line;
       std::getline(file, empty_line);

--- a/tests/test_sha3_256.cpp
+++ b/tests/test_sha3_256.cpp
@@ -5,6 +5,42 @@
 #include <gtest/gtest.h>
 #include <vector>
 
+// Eval SHA3-256 hash on statically defined input message during
+// compilation-time.
+constexpr std::array<uint8_t, sha3_256::DIGEST_LEN>
+eval_sha3_256()
+{
+  // Statically defined input.
+  std::array<uint8_t, sha3_256::DIGEST_LEN * 2> data{};
+  std::iota(data.begin(), data.end(), 0);
+
+  // To be computed output.
+  std::array<uint8_t, sha3_256::DIGEST_LEN> md{};
+
+  sha3_256::sha3_256_t hasher;
+  hasher.absorb(data);
+  hasher.finalize();
+  hasher.digest(md);
+
+  return md;
+}
+
+// Ensure that SHA3-256 implementation is compile-time evaluable.
+TEST(Sha3Hashing, CompileTimeEvalSha3_256)
+{
+  // Input  =
+  // 000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f
+  // Output = c8ad478f4e1dd9d47dfc3b985708d92db1f8db48fe9cddd459e63c321f490402
+
+  constexpr auto md = eval_sha3_256();
+  static_assert(md ==
+                  std::array<uint8_t, sha3_256::DIGEST_LEN>{
+                    200, 173, 71, 143, 78, 29,  217, 212, 125, 252, 59,
+                    152, 87,  8,  217, 45, 177, 248, 219, 72,  254, 156,
+                    221, 212, 89, 230, 60, 50,  31,  73,  4,   2 },
+                "Must be able to compute Sha3-256 hash during compile-time !");
+}
+
 // Test that absorbing same input message bytes using both incremental and
 // one-shot hashing, should yield same output bytes, for SHA3-256 hasher.
 TEST(Sha3Hashing, Sha3_256IncrementalAbsorption)

--- a/tests/test_sha3_256.cpp
+++ b/tests/test_sha3_256.cpp
@@ -16,7 +16,7 @@ TEST(Sha3Hashing, Sha3_256IncrementalAbsorption)
 
     sha3_utils::random_data(msg.data(), msg.size());
 
-    sha3_256::sha3_256 hasher;
+    sha3_256::sha3_256_t hasher;
 
     // Oneshot Hashing
     hasher.absorb(msg.data(), msg.size());
@@ -73,7 +73,7 @@ TEST(Sha3Hashing, Sha3_256KnownAnswerTests)
 
       std::vector<uint8_t> digest(sha3_256::DIGEST_LEN);
 
-      sha3_256::sha3_256 hasher;
+      sha3_256::sha3_256_t hasher;
 
       hasher.absorb(msg.data(), msg.size());
       hasher.finalize();

--- a/tests/test_sha3_384.cpp
+++ b/tests/test_sha3_384.cpp
@@ -16,7 +16,7 @@ TEST(Sha3Hashing, Sha3_384IncrementalAbsorption)
 
     sha3_utils::random_data(msg.data(), msg.size());
 
-    sha3_384::sha3_384 hasher;
+    sha3_384::sha3_384_t hasher;
 
     // Oneshot Hashing
     hasher.absorb(msg.data(), msg.size());
@@ -73,7 +73,7 @@ TEST(Sha3Hashing, Sha3_384KnownAnswerTests)
 
       std::vector<uint8_t> digest(sha3_384::DIGEST_LEN);
 
-      sha3_384::sha3_384 hasher;
+      sha3_384::sha3_384_t hasher;
 
       hasher.absorb(msg.data(), msg.size());
       hasher.finalize();

--- a/tests/test_sha3_384.cpp
+++ b/tests/test_sha3_384.cpp
@@ -14,14 +14,18 @@ TEST(Sha3Hashing, Sha3_384IncrementalAbsorption)
     std::vector<uint8_t> out0(sha3_384::DIGEST_LEN);
     std::vector<uint8_t> out1(sha3_384::DIGEST_LEN);
 
-    sha3_utils::random_data(msg.data(), msg.size());
+    auto _msg = std::span(msg);
+    auto _out0 = std::span<uint8_t, sha3_384::DIGEST_LEN>(out0);
+    auto _out1 = std::span<uint8_t, sha3_384::DIGEST_LEN>(out1);
+
+    sha3_utils::random_data(_msg);
 
     sha3_384::sha3_384_t hasher;
 
     // Oneshot Hashing
-    hasher.absorb(msg.data(), msg.size());
+    hasher.absorb(_msg);
     hasher.finalize();
-    hasher.digest(out0.data());
+    hasher.digest(_out0);
 
     hasher.reset();
 
@@ -31,14 +35,14 @@ TEST(Sha3Hashing, Sha3_384IncrementalAbsorption)
       // because we don't want to be stuck in an infinite loop if msg[off] = 0 !
       auto elen = std::min<size_t>(std::max<uint8_t>(msg[off], 1), mlen - off);
 
-      hasher.absorb(msg.data() + off, elen);
+      hasher.absorb(_msg.subspan(off, elen));
       off += elen;
     }
 
     hasher.finalize();
-    hasher.digest(out1.data());
+    hasher.digest(_out1);
 
-    ASSERT_TRUE(std::ranges::equal(out0, out1));
+    EXPECT_EQ(out0, out1);
   }
 }
 
@@ -72,14 +76,15 @@ TEST(Sha3Hashing, Sha3_384KnownAnswerTests)
       auto md = sha3_utils::from_hex(md2);
 
       std::vector<uint8_t> digest(sha3_384::DIGEST_LEN);
+      auto _digest = std::span<uint8_t, sha3_384::DIGEST_LEN>(digest);
 
       sha3_384::sha3_384_t hasher;
 
-      hasher.absorb(msg.data(), msg.size());
+      hasher.absorb(msg);
       hasher.finalize();
-      hasher.digest(digest.data());
+      hasher.digest(_digest);
 
-      ASSERT_TRUE(std::ranges::equal(digest, md));
+      EXPECT_EQ(digest, md);
 
       std::string empty_line;
       std::getline(file, empty_line);

--- a/tests/test_sha3_384.cpp
+++ b/tests/test_sha3_384.cpp
@@ -5,6 +5,45 @@
 #include <gtest/gtest.h>
 #include <vector>
 
+// Eval SHA3-384 hash on statically defined input message during
+// compilation-time.
+constexpr std::array<uint8_t, sha3_384::DIGEST_LEN>
+eval_sha3_384()
+{
+  // Statically defined input.
+  std::array<uint8_t, sha3_384::DIGEST_LEN * 2> data{};
+  std::iota(data.begin(), data.end(), 0);
+
+  // To be computed output.
+  std::array<uint8_t, sha3_384::DIGEST_LEN> md{};
+
+  sha3_384::sha3_384_t hasher;
+  hasher.absorb(data);
+  hasher.finalize();
+  hasher.digest(md);
+
+  return md;
+}
+
+// Ensure that SHA3-384 implementation is compile-time evaluable.
+TEST(Sha3Hashing, CompileTimeEvalSha3_384)
+{
+  // Input  =
+  // 000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f
+  // Output =
+  // d6e266970a3fdcd4a833da861599179a060b576959e993b4698529304ee38c23c7102a7084c4d568b1d95523d14077e7
+
+  constexpr auto md = eval_sha3_384();
+  static_assert(
+    md ==
+      std::array<uint8_t, sha3_384::DIGEST_LEN>{
+        214, 226, 102, 151, 10,  63,  220, 212, 168, 51,  218, 134,
+        21,  153, 23,  154, 6,   11,  87,  105, 89,  233, 147, 180,
+        105, 133, 41,  48,  78,  227, 140, 35,  199, 16,  42,  112,
+        132, 196, 213, 104, 177, 217, 85,  35,  209, 64,  119, 231 },
+    "Must be able to compute Sha3-384 hash during compile-time !");
+}
+
 // Test that absorbing same input message bytes using both incremental and
 // one-shot hashing, should yield same output bytes, for SHA3-384 hasher.
 TEST(Sha3Hashing, Sha3_384IncrementalAbsorption)

--- a/tests/test_sha3_512.cpp
+++ b/tests/test_sha3_512.cpp
@@ -5,6 +5,46 @@
 #include <gtest/gtest.h>
 #include <vector>
 
+// Eval SHA3-512 hash on statically defined input message during
+// compilation-time.
+constexpr std::array<uint8_t, sha3_512::DIGEST_LEN>
+eval_sha3_512()
+{
+  // Statically defined input.
+  std::array<uint8_t, sha3_512::DIGEST_LEN * 2> data{};
+  std::iota(data.begin(), data.end(), 0);
+
+  // To be computed output.
+  std::array<uint8_t, sha3_512::DIGEST_LEN> md{};
+
+  sha3_512::sha3_512_t hasher;
+  hasher.absorb(data);
+  hasher.finalize();
+  hasher.digest(md);
+
+  return md;
+}
+
+// Ensure that SHA3-512 implementation is compile-time evaluable.
+TEST(Sha3Hashing, CompileTimeEvalSha3_512)
+{
+  // Input  =
+  // 000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f
+  // Output =
+  // 989c1995da9d2d341f993c2e2ca695f3477075061bfbd2cdf0be75cf7ba99fbe33d8d2c4dcc31fa89917786b883e6c9d5b02ed81b7483a4cb3ea98671588f745
+
+  constexpr auto md = eval_sha3_512();
+  static_assert(md ==
+                  std::array<uint8_t, sha3_512::DIGEST_LEN>{
+                    152, 156, 25,  149, 218, 157, 45,  52,  31,  153, 60,
+                    46,  44,  166, 149, 243, 71,  112, 117, 6,   27,  251,
+                    210, 205, 240, 190, 117, 207, 123, 169, 159, 190, 51,
+                    216, 210, 196, 220, 195, 31,  168, 153, 23,  120, 107,
+                    136, 62,  108, 157, 91,  2,   237, 129, 183, 72,  58,
+                    76,  179, 234, 152, 103, 21,  136, 247, 69 },
+                "Must be able to compute Sha3-512 hash during compile-time !");
+}
+
 // Test that absorbing same input message bytes using both incremental and
 // one-shot hashing, should yield same output bytes, for SHA3-512 hasher.
 TEST(Sha3Hashing, Sha3_512IncrementalAbsorption)

--- a/tests/test_sha3_512.cpp
+++ b/tests/test_sha3_512.cpp
@@ -16,7 +16,7 @@ TEST(Sha3Hashing, Sha3_512IncrementalAbsorption)
 
     sha3_utils::random_data(msg.data(), msg.size());
 
-    sha3_512::sha3_512 hasher;
+    sha3_512::sha3_512_t hasher;
 
     // Oneshot Hashing
     hasher.absorb(msg.data(), msg.size());
@@ -73,7 +73,7 @@ TEST(Sha3Hashing, Sha3_512KnownAnswerTests)
 
       std::vector<uint8_t> digest(sha3_512::DIGEST_LEN);
 
-      sha3_512::sha3_512 hasher;
+      sha3_512::sha3_512_t hasher;
 
       hasher.absorb(msg.data(), msg.size());
       hasher.finalize();

--- a/tests/test_shake128.cpp
+++ b/tests/test_shake128.cpp
@@ -5,6 +5,60 @@
 #include <gtest/gtest.h>
 #include <vector>
 
+// Eval Shake128 Xof on statically defined input message during
+// compilation-time.
+constexpr std::array<uint8_t, 256>
+eval_shake128()
+{
+  // Statically defined input.
+  std::array<uint8_t, 256> data{};
+  std::iota(data.begin(), data.end(), 0);
+
+  // To be computed output.
+  std::array<uint8_t, 256> md{};
+
+  shake128::shake128_t hasher;
+  hasher.absorb(data);
+  hasher.finalize();
+  hasher.squeeze(md);
+
+  return md;
+}
+
+// Ensure that Shake128 Xof implementation is compile-time evaluable.
+TEST(Sha3Xof, CompileTimeEvalShake128)
+{
+  // Input  =
+  // 000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff
+  // Output =
+  // 9d32ba2aa8f40b0cdf108376d77abfd5c97f149e6ba0c9efe3499c7b3c039b0afac641a978ef435b3d83b9712da8ea826bb38078899b3efaec77d44a0460b220225d1b0b11a1d1c5cb0acb5aca92c6fb95f64a992eee6b6de24434aae4fba9d496bd8bd90624391f79c0db7d20eef1ddbfe8d771b4123e97ad7664012188590eb0b43c7073b7a9ab8af27229bc7246296ac0e172fca7314b8f100dc247d51c949bc4977c345d7c1d5536c96825f3650b7f80b5981b252ce4a858e54f9833cceaf38c12a91a8c6b341e197eb894553ca6f100f731f00f43b854098aace7a4e0ed8252782523f561dd994c291229eaf70185c98ed0026be1bd39c17dd817424009
+
+  constexpr auto md = eval_shake128();
+  static_assert(
+    md ==
+      std::array<uint8_t, 256>{
+        157, 50,  186, 42,  168, 244, 11,  12,  223, 16,  131, 118, 215, 122,
+        191, 213, 201, 127, 20,  158, 107, 160, 201, 239, 227, 73,  156, 123,
+        60,  3,   155, 10,  250, 198, 65,  169, 120, 239, 67,  91,  61,  131,
+        185, 113, 45,  168, 234, 130, 107, 179, 128, 120, 137, 155, 62,  250,
+        236, 119, 212, 74,  4,   96,  178, 32,  34,  93,  27,  11,  17,  161,
+        209, 197, 203, 10,  203, 90,  202, 146, 198, 251, 149, 246, 74,  153,
+        46,  238, 107, 109, 226, 68,  52,  170, 228, 251, 169, 212, 150, 189,
+        139, 217, 6,   36,  57,  31,  121, 192, 219, 125, 32,  238, 241, 221,
+        191, 232, 215, 113, 180, 18,  62,  151, 173, 118, 100, 1,   33,  136,
+        89,  14,  176, 180, 60,  112, 115, 183, 169, 171, 138, 242, 114, 41,
+        188, 114, 70,  41,  106, 192, 225, 114, 252, 167, 49,  75,  143, 16,
+        13,  194, 71,  213, 28,  148, 155, 196, 151, 124, 52,  93,  124, 29,
+        85,  54,  201, 104, 37,  243, 101, 11,  127, 128, 181, 152, 27,  37,
+        44,  228, 168, 88,  229, 79,  152, 51,  204, 234, 243, 140, 18,  169,
+        26,  140, 107, 52,  30,  25,  126, 184, 148, 85,  60,  166, 241, 0,
+        247, 49,  240, 15,  67,  184, 84,  9,   138, 172, 231, 164, 224, 237,
+        130, 82,  120, 37,  35,  245, 97,  221, 153, 76,  41,  18,  41,  234,
+        247, 1,   133, 201, 142, 208, 2,   107, 225, 189, 57,  193, 125, 216,
+        23,  66,  64,  9 },
+    "Must be able to compute Shake128 Xof during compile-time !");
+}
+
 // Test that absorbing same message bytes using both incremental and one-shot
 // hashing, should yield same output bytes, for SHAKE128 XOF.
 //

--- a/tests/test_shake128.cpp
+++ b/tests/test_shake128.cpp
@@ -20,7 +20,7 @@ TEST(Sha3Xof, Shake128IncrementalAbsorptionAndSqueezing)
 
       sha3_utils::random_data(msg.data(), msg.size());
 
-      shake128::shake128 hasher;
+      shake128::shake128_t hasher;
 
       // Oneshot absorption and squeezing
       hasher.absorb(msg.data(), msg.size());
@@ -90,7 +90,7 @@ TEST(Sha3Xof, Shake128KnownAnswerTests)
 
       std::vector<uint8_t> squeezed(out.size());
 
-      shake128::shake128 hasher;
+      shake128::shake128_t hasher;
 
       hasher.absorb(msg.data(), msg.size());
       hasher.finalize();

--- a/tests/test_shake256.cpp
+++ b/tests/test_shake256.cpp
@@ -20,7 +20,7 @@ TEST(Sha3Xof, Shake256IncrementalAbsorptionAndSqueezing)
 
       sha3_utils::random_data(msg.data(), msg.size());
 
-      shake256::shake256 hasher;
+      shake256::shake256_t hasher;
 
       // Oneshot absorption and squeezing
       hasher.absorb(msg.data(), msg.size());
@@ -90,7 +90,7 @@ TEST(Sha3Xof, Shake256KnownAnswerTests)
 
       std::vector<uint8_t> squeezed(out.size());
 
-      shake256::shake256 hasher;
+      shake256::shake256_t hasher;
 
       hasher.absorb(msg.data(), msg.size());
       hasher.finalize();

--- a/tests/test_shake256.cpp
+++ b/tests/test_shake256.cpp
@@ -5,6 +5,60 @@
 #include <gtest/gtest.h>
 #include <vector>
 
+// Eval Shake256 Xof on statically defined input message during
+// compilation-time.
+constexpr std::array<uint8_t, 256>
+eval_shake256()
+{
+  // Statically defined input.
+  std::array<uint8_t, 256> data{};
+  std::iota(data.begin(), data.end(), 0);
+
+  // To be computed output.
+  std::array<uint8_t, 256> md{};
+
+  shake256::shake256_t hasher;
+  hasher.absorb(data);
+  hasher.finalize();
+  hasher.squeeze(md);
+
+  return md;
+}
+
+// Ensure that Shake256 Xof implementation is compile-time evaluable.
+TEST(Sha3Xof, CompileTimeEvalShake256)
+{
+  // Input  =
+  // 000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff
+  // Output =
+  // 336c8aa7f2b08bda6bd7402cd2ea89760b7728a8b31802b80524756361165366ff8159f2f4568a2bfa286db6387895629938c2868a6421c37f988455763a75e4b9259e0a939aaa68295119ccea72c9f0ca7d048aa70eeeb4534c6bd08ecc6163217c790f33b84a89623f8e5538b734967e9490a48b7d0658afb4565364e8b234dfe6a2bceb12ce2130eec00bf2113615a276819d7815f5891d07600275f4d8fbc87b056f44bc2b141ca5ed9e4cb6e9a7bf71f520971dca1c8da6140e2af31faef5502e84991a2d9e9a80183c174cc105ef178d5f6fa45b0f284eb7bced20a47c3f584aca27eac5558da517af7569fe2e843461b4b65f81f819bf81aae6dfaa3b
+
+  constexpr auto md = eval_shake256();
+  static_assert(
+    md ==
+      std::array<uint8_t, 256>{
+        51,  108, 138, 167, 242, 176, 139, 218, 107, 215, 64,  44,  210, 234,
+        137, 118, 11,  119, 40,  168, 179, 24,  2,   184, 5,   36,  117, 99,
+        97,  22,  83,  102, 255, 129, 89,  242, 244, 86,  138, 43,  250, 40,
+        109, 182, 56,  120, 149, 98,  153, 56,  194, 134, 138, 100, 33,  195,
+        127, 152, 132, 85,  118, 58,  117, 228, 185, 37,  158, 10,  147, 154,
+        170, 104, 41,  81,  25,  204, 234, 114, 201, 240, 202, 125, 4,   138,
+        167, 14,  238, 180, 83,  76,  107, 208, 142, 204, 97,  99,  33,  124,
+        121, 15,  51,  184, 74,  137, 98,  63,  142, 85,  56,  183, 52,  150,
+        126, 148, 144, 164, 139, 125, 6,   88,  175, 180, 86,  83,  100, 232,
+        178, 52,  223, 230, 162, 188, 235, 18,  206, 33,  48,  238, 192, 11,
+        242, 17,  54,  21,  162, 118, 129, 157, 120, 21,  245, 137, 29,  7,
+        96,  2,   117, 244, 216, 251, 200, 123, 5,   111, 68,  188, 43,  20,
+        28,  165, 237, 158, 76,  182, 233, 167, 191, 113, 245, 32,  151, 29,
+        202, 28,  141, 166, 20,  14,  42,  243, 31,  174, 245, 80,  46,  132,
+        153, 26,  45,  158, 154, 128, 24,  60,  23,  76,  193, 5,   239, 23,
+        141, 95,  111, 164, 91,  15,  40,  78,  183, 188, 237, 32,  164, 124,
+        63,  88,  74,  202, 39,  234, 197, 85,  141, 165, 23,  175, 117, 105,
+        254, 46,  132, 52,  97,  180, 182, 95,  129, 248, 25,  191, 129, 170,
+        230, 223, 170, 59 },
+    "Must be able to compute Shake256 Xof during compile-time !");
+}
+
 // Test that absorbing same message bytes using both incremental and one-shot
 // hashing, should yield same output bytes, for SHAKE256 XOF.
 //

--- a/tests/test_shake256.cpp
+++ b/tests/test_shake256.cpp
@@ -18,14 +18,18 @@ TEST(Sha3Xof, Shake256IncrementalAbsorptionAndSqueezing)
       std::vector<uint8_t> out0(olen);
       std::vector<uint8_t> out1(olen);
 
-      sha3_utils::random_data(msg.data(), msg.size());
+      auto _msg = std::span(msg);
+      auto _out0 = std::span(out0);
+      auto _out1 = std::span(out1);
+
+      sha3_utils::random_data(_msg);
 
       shake256::shake256_t hasher;
 
       // Oneshot absorption and squeezing
-      hasher.absorb(msg.data(), msg.size());
+      hasher.absorb(_msg);
       hasher.finalize();
-      hasher.squeeze(out0.data(), out0.size());
+      hasher.squeeze(_out0);
 
       hasher.reset();
 
@@ -36,7 +40,7 @@ TEST(Sha3Xof, Shake256IncrementalAbsorptionAndSqueezing)
         auto tmp = std::max<uint8_t>(msg[off], 1);
         auto elen = std::min<size_t>(tmp, mlen - off);
 
-        hasher.absorb(msg.data() + off, elen);
+        hasher.absorb(_msg.subspan(off, elen));
         off += elen;
       }
 
@@ -45,16 +49,16 @@ TEST(Sha3Xof, Shake256IncrementalAbsorptionAndSqueezing)
       // squeeze message bytes in many iterations
       off = 0;
       while (off < olen) {
-        hasher.squeeze(out1.data() + off, 1);
+        hasher.squeeze(_out1.subspan(off, 1));
 
         auto elen = std::min<size_t>(out1[off], olen - (off + 1));
 
         off += 1;
-        hasher.squeeze(out1.data() + off, elen);
+        hasher.squeeze(_out1.subspan(off, elen));
         off += elen;
       }
 
-      ASSERT_TRUE(std::ranges::equal(out0, out1));
+      EXPECT_EQ(out0, out1);
     }
   }
 }
@@ -92,11 +96,11 @@ TEST(Sha3Xof, Shake256KnownAnswerTests)
 
       shake256::shake256_t hasher;
 
-      hasher.absorb(msg.data(), msg.size());
+      hasher.absorb(msg);
       hasher.finalize();
-      hasher.squeeze(squeezed.data(), squeezed.size());
+      hasher.squeeze(squeezed);
 
-      ASSERT_TRUE(std::ranges::equal(squeezed, out));
+      EXPECT_EQ(squeezed, out);
 
       std::string empty_line;
       std::getline(file, empty_line);


### PR DESCRIPTION
Make whole implementation of SHA3 standard `constexpr` ( more @ https://en.cppreference.com/w/cpp/language/constexpr ) so that one can evaluate SHA3-{224, 256, 384, 512} and SHAKE-{128, 256} hash function/ xof on statically defined input data during compilation time itself.

```cpp
#include "sha3_256.hpp"
#include <gtest/gtest.h>

constexpr std::array<uint8_t, sha3_256::DIGEST_LEN>
eval_sha3_256()
{
  // Statically defined input.
  std::array<uint8_t, sha3_256::DIGEST_LEN * 2> data{};
  std::iota(data.begin(), data.end(), 0);

  // To be computed output.
  std::array<uint8_t, sha3_256::DIGEST_LEN> md{};

  sha3_256::sha3_256_t hasher;
  hasher.absorb(data);
  hasher.finalize();
  hasher.digest(md);

  return md;
}

TEST(Sha3Hashing, CompileTimeEvalSha3_256)
{
  // Input  = 000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f
  // Output = c8ad478f4e1dd9d47dfc3b985708d92db1f8db48fe9cddd459e63c321f490402

  constexpr auto md = eval_sha3_256();
  static_assert(md ==
                  std::array<uint8_t, sha3_256::DIGEST_LEN>{
                    200, 173, 71, 143, 78, 29,  217, 212, 125, 252, 59,
                    152, 87,  8,  217, 45, 177, 248, 219, 72,  254, 156,
                    221, 212, 89, 230, 60, 50,  31,  73,  4,   2 },
                "Must compute Sha3-256 hash during compile-time !");
}
```